### PR TITLE
C2PA-37: Do not perform XMP writes for fonts.

### DIFF
--- a/sdk/src/asset_handlers/jpeg_io.rs
+++ b/sdk/src/asset_handlers/jpeg_io.rs
@@ -31,6 +31,9 @@ use crate::{
     error::{Error, Result},
 };
 
+#[cfg(feature="xmp_write")]
+use crate::embedded_xmp::{add_manifest_uri_to_file, XMPIO};
+
 const XMP_SIGNATURE: &[u8] = b"http://ns.adobe.com/xap/1.0/";
 const XMP_SIGNATURE_BUFFER_SIZE: usize = XMP_SIGNATURE.len() + 1; // skip null or space char at end
 
@@ -455,6 +458,13 @@ impl AssetIO for JpegIO {
             .map_err(|_err| Error::InvalidAsset("JPEG write error".to_owned()))?;
 
         Ok(())
+    }
+}
+
+#[cfg(feature="xmp_write")]
+impl XMPIO for JpegIO {
+    fn add_manifest_uri(&self, asset_path: &std::path::Path, manifest_uri: &str) -> Result<()> {
+        add_manifest_uri_to_file(asset_path, manifest_uri)
     }
 }
 

--- a/sdk/src/asset_handlers/png_io.rs
+++ b/sdk/src/asset_handlers/png_io.rs
@@ -25,6 +25,9 @@ use crate::{
     error::{Error, Result},
 };
 
+#[cfg(feature="xmp_write")]
+use crate::embedded_xmp::{add_manifest_uri_to_file, XMPIO};
+
 const PNG_ID: [u8; 8] = [137, 80, 78, 71, 13, 10, 26, 10];
 const CAI_CHUNK: [u8; 4] = *b"caBX";
 const IMG_HDR: [u8; 4] = *b"IHDR";
@@ -418,6 +421,13 @@ impl AssetIO for PngIO {
         std::fs::write(asset_path, png_buf)?;
 
         Ok(())
+    }
+}
+
+#[cfg(feature="xmp_write")]
+impl XMPIO for PngIO {
+    fn add_manifest_uri(&self, asset_path: &std::path::Path, manifest_uri: &str) -> Result<()> {
+        add_manifest_uri_to_file(asset_path, manifest_uri)
     }
 }
 

--- a/sdk/src/asset_handlers/tiff_io.rs
+++ b/sdk/src/asset_handlers/tiff_io.rs
@@ -28,6 +28,9 @@ use crate::{
     error::{Error, Result},
 };
 
+#[cfg(feature = "xmp_write")]
+use crate::embedded_xmp::{add_manifest_uri_to_file, XMPIO};
+
 const II: [u8; 2] = *b"II";
 const MM: [u8; 2] = *b"MM";
 
@@ -1497,6 +1500,13 @@ impl AssetPatch for TiffIO {
                 "patch_cai_store store size mismatch.".to_string(),
             ))
         }
+    }
+}
+
+#[cfg(feature="xmp_write")]
+impl XMPIO for TiffIO {
+    fn add_manifest_uri(&self, asset_path: &std::path::Path, manifest_uri: &str) -> Result<()> {
+        add_manifest_uri_to_file(asset_path, manifest_uri)
     }
 }
 

--- a/sdk/src/embedded_xmp.rs
+++ b/sdk/src/embedded_xmp.rs
@@ -16,7 +16,39 @@ use std::path::Path;
 use log::error;
 use xmp_toolkit::{OpenFileOptions, XmpError, XmpErrorType, XmpFile, XmpMeta};
 
-use crate::{Error, Result};
+use crate::{
+    Error, Result,
+    asset_handlers::{jpeg_io::JpegIO, png_io::PngIO, tiff_io::TiffIO}
+};
+
+
+/// XMP IO object.
+pub trait XMPIO {
+    /// Add the URI for the active manifest to the XMP packet for a file.
+    ///
+    /// This will replace any existing `dc:provenance` term
+    /// in the file's metadata, or create a new one if necessary.
+    ///
+    /// This does not check the claim at all; it is presumed
+    /// that the string that is passed is a valid signed claim.
+    fn add_manifest_uri(&self, asset_path: &Path, manifest_uri: &str) -> Result<()>;
+}
+
+/// Gets a XMP IO handler for writing a manifest URI
+/// 
+/// ## Arguments
+/// * `ext`: Extension of asset
+/// 
+/// Returns a `XMPIO` object for writing XMP data.
+pub fn get_xmp_io_handler(ext: &str) -> Option<Box<dyn XMPIO>> {
+    let ext = ext.to_lowercase();
+    match ext.as_ref() {
+        "jpg" | "jpeg" => Some(Box::new(JpegIO {})),
+        "png" => Some(Box::new(PngIO {})),
+        "tif" | "tiff" | "dng" => Some(Box::new(TiffIO {})),
+        _ => None,
+    }
+}
 
 /// Add the URI for the active manifest to the XMP packet for a file.
 ///

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -173,6 +173,9 @@ pub enum Error {
     #[error("could not fetch the remote manifest")]
     RemoteManifestFetch(String),
 
+    #[error("use of remote manifest not supported for type")]
+    RemoteManifestNotSupported,
+
     #[error("must fetch remote manifests from url")]
     RemoteManifestUrl(String),
 

--- a/sdk/src/jumbf_io.rs
+++ b/sdk/src/jumbf_io.rs
@@ -74,6 +74,19 @@ static BMFF_TYPES: [&str; 12] = [
     "video/mp4",
 ];
 
+#[cfg(all(feature = "otf", feature = "file_io"))]
+static FONT_TYPES: [&str; 4] = [
+    "otf",
+    "ttf",
+    "application/font-sfnt",
+    "font/ttf",
+];
+
+#[cfg(all(feature = "otf", feature = "file_io"))]
+pub(crate) fn is_font_type(asset_type: &str) -> bool {
+    FONT_TYPES.contains(&asset_type)
+}
+
 #[cfg(feature = "file_io")]
 pub(crate) fn is_bmff_format(asset_type: &str) -> bool {
     BMFF_TYPES.contains(&asset_type)

--- a/sdk/src/jumbf_io.rs
+++ b/sdk/src/jumbf_io.rs
@@ -28,7 +28,7 @@ use crate::{
     error::{Error, Result},
 };
 
-static SUPPORTED_TYPES: [&str; 27] = [
+static SUPPORTED_TYPES: [&str; 30] = [
     "avif",
     "c2pa", // stand-alone manifest file
     "heif",
@@ -50,9 +50,12 @@ static SUPPORTED_TYPES: [&str; 27] = [
     "image/jpeg",
     "image/png",
     "video/mp4",
-    "application/font-sfnt",
     "otf",
     "ttf",
+    "sfnt",
+    "application/font-sfnt",
+    "font/otf",
+    "font/sfnt",
     "font/ttf",
     "image/tiff",
     "image/dng",
@@ -74,18 +77,16 @@ static BMFF_TYPES: [&str; 12] = [
     "video/mp4",
 ];
 
-#[cfg(all(feature = "otf", feature = "file_io"))]
-static FONT_TYPES: [&str; 4] = [
+#[cfg(feature = "otf")]
+static FONT_TYPES: [&str; 7] = [
     "otf",
     "ttf",
+    "sfnt",
     "application/font-sfnt",
+    "font/otf",
+    "font/sfnt",
     "font/ttf",
 ];
-
-#[cfg(all(feature = "otf", feature = "file_io"))]
-pub(crate) fn is_font_type(asset_type: &str) -> bool {
-    FONT_TYPES.contains(&asset_type)
-}
 
 #[cfg(feature = "file_io")]
 pub(crate) fn is_bmff_format(asset_type: &str) -> bool {
@@ -138,7 +139,7 @@ pub fn get_assetio_handler(ext: &str) -> Option<Box<dyn AssetIO>> {
         "png" => Some(Box::new(PngIO {})),
         "mp4" | "m4a" | "mov" if cfg!(feature = "bmff") => Some(Box::new(BmffIO::new(&ext))),
         #[cfg(feature = "otf")]
-        "otf" | "ttf" => Some(Box::new(OtfIO {})),
+        "otf" | "ttf" | "sfnt" => Some(Box::new(OtfIO {})),
         "tif" | "tiff" | "dng" => Some(Box::new(TiffIO {})),
         _ => None,
     }
@@ -153,7 +154,7 @@ pub fn get_cailoader_handler(asset_type: &str) -> Option<Box<dyn CAILoader>> {
         "jpg" | "jpeg" | "image/jpeg" => Some(Box::new(JpegIO {})),
         "png" | "image/png" => Some(Box::new(PngIO {})),
         #[cfg(feature = "otf")]
-        "otf" | "application/font-sfnt" | "ttf" | "font/ttf" => Some(Box::new(OtfIO {})),
+        _ if FONT_TYPES.contains(&asset_type.as_ref()) => Some(Box::new(OtfIO {})),
         "avif" | "heif" | "heic" | "mp4" | "m4a" | "application/mp4" | "audio/mp4"
         | "image/avif" | "image/heic" | "image/heif" | "video/mp4"
             if cfg!(feature = "bmff") && !cfg!(target_arch = "wasm32") =>

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -57,6 +57,12 @@ use crate::{
         object_locations, remove_jumbf_from_file, save_jumbf_to_file,
     },
 };
+#[cfg(all(feature = "otf", feature = "file_io"))]
+use crate:: {
+    jumbf_io::{
+        is_font_type,
+    },
+};
 
 const MANIFEST_STORE_EXT: &str = "c2pa"; // file extension for external manifests
 
@@ -1728,6 +1734,14 @@ impl Store {
             }
         };
 
+        // XMP doesn't make sense in the form of a font file, so we skip the creation of XMP
+        // for fonts
+        let is_font_type = match cfg!(feature = "otf") && cfg!(feature = "file_io") {
+            #[cfg(all(feature = "otf", feature = "file_io"))]
+            true => is_font_type(&ext),
+            _ => false,
+        };
+
         if asset_path != dest_path {
             fs::copy(asset_path, dest_path).map_err(Error::IoError)?;
         }
@@ -1742,8 +1756,10 @@ impl Store {
                 // the class embedded_xmp is not defined so we have to explicitly exclude it from the build
                 #[cfg(feature = "xmp_write")]
                 if let Some(provenance) = self.provenance_path() {
-                    // update XMP info & add xmp hash to provenance claim
-                    embedded_xmp::add_manifest_uri_to_file(dest_path, &provenance)?;
+                    if !is_font_type {
+                        // update XMP info & add xmp hash to provenance claim
+                        embedded_xmp::add_manifest_uri_to_file(dest_path, &provenance)?;
+                    }
                 } else {
                     return Err(Error::XmpWriteError);
                 }
@@ -1759,7 +1775,7 @@ impl Store {
                 }
             }
             crate::claim::RemoteManifest::Remote(_url) => {
-                if cfg!(feature = "xmp_write") {
+                if cfg!(feature = "xmp_write") && !is_font_type {
                     let d = dest_path.with_extension(MANIFEST_STORE_EXT);
                     // remove any previous c2pa manifest from the asset
                     remove_jumbf_from_file(dest_path)?;
@@ -1773,7 +1789,7 @@ impl Store {
                 }
             }
             crate::claim::RemoteManifest::EmbedWithRemote(_url) => {
-                if cfg!(feature = "xmp_write") {
+                if cfg!(feature = "xmp_write") && !is_font_type {
                     // even though this block is protected by the outer cfg!(feature = "xmp_write")
                     // the class embedded_xmp is not defined so we have to explicitly exclude it from the build
                     #[cfg(feature = "xmp_write")]


### PR DESCRIPTION
## Changes in this pull request
_Give a narrative description of what has been changed._

When adding support for font types, we had to temporarily disable the XMP writing, since it is not valid for a Font file. This change allows for the `xmp_write` feature to be used with the `otf` feature. In essence allowing for a single compile of the SDK to allow writing manifests to a font file and an image file.

The `c2patool` has a draft PR referencing this branch for testing: https://github.com/Monotype/c2patool/pull/1.

## Checklist
- [X] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
