### PR TITLE
C2PA-37: Partially allow font support with `xmp_write` feature

### DIFF
--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -173,6 +173,9 @@ pub enum Error {
     #[error("could not fetch the remote manifest")]
     RemoteManifestFetch(String),
 
+    #[error("use of remote manifest not supported for type")]
+    RemoteManifestNotSupported,
+
     #[error("must fetch remote manifests from url")]
     RemoteManifestUrl(String),
 

--- a/sdk/src/jumbf_io.rs
+++ b/sdk/src/jumbf_io.rs
@@ -28,7 +28,7 @@ use crate::{
     error::{Error, Result},
 };
 
-static SUPPORTED_TYPES: [&str; 27] = [
+static SUPPORTED_TYPES: [&str; 30] = [
     "avif",
     "c2pa", // stand-alone manifest file
     "heif",
@@ -50,9 +50,12 @@ static SUPPORTED_TYPES: [&str; 27] = [
     "image/jpeg",
     "image/png",
     "video/mp4",
-    "application/font-sfnt",
     "otf",
     "ttf",
+    "sfnt",
+    "application/font-sfnt",
+    "font/otf",
+    "font/sfnt",
     "font/ttf",
     "image/tiff",
     "image/dng",
@@ -74,11 +77,14 @@ static BMFF_TYPES: [&str; 12] = [
     "video/mp4",
 ];
 
-#[cfg(all(feature = "otf", feature = "file_io"))]
-static FONT_TYPES: [&str; 4] = [
+#[cfg(feature = "otf")]
+static FONT_TYPES: [&str; 7] = [
     "otf",
     "ttf",
+    "sfnt",
     "application/font-sfnt",
+    "font/otf",
+    "font/sfnt",
     "font/ttf",
 ];
 
@@ -138,7 +144,7 @@ pub fn get_assetio_handler(ext: &str) -> Option<Box<dyn AssetIO>> {
         "png" => Some(Box::new(PngIO {})),
         "mp4" | "m4a" | "mov" if cfg!(feature = "bmff") => Some(Box::new(BmffIO::new(&ext))),
         #[cfg(feature = "otf")]
-        "otf" | "ttf" => Some(Box::new(OtfIO {})),
+        "otf" | "ttf" | "sfnt" => Some(Box::new(OtfIO {})),
         "tif" | "tiff" | "dng" => Some(Box::new(TiffIO {})),
         _ => None,
     }
@@ -153,7 +159,7 @@ pub fn get_cailoader_handler(asset_type: &str) -> Option<Box<dyn CAILoader>> {
         "jpg" | "jpeg" | "image/jpeg" => Some(Box::new(JpegIO {})),
         "png" | "image/png" => Some(Box::new(PngIO {})),
         #[cfg(feature = "otf")]
-        "otf" | "application/font-sfnt" | "ttf" | "font/ttf" => Some(Box::new(OtfIO {})),
+        _ if FONT_TYPES.contains(&asset_type.as_ref()) => Some(Box::new(OtfIO {})),
         "avif" | "heif" | "heic" | "mp4" | "m4a" | "application/mp4" | "audio/mp4"
         | "image/avif" | "image/heic" | "image/heif" | "video/mp4"
             if cfg!(feature = "bmff") && !cfg!(target_arch = "wasm32") =>

--- a/sdk/src/jumbf_io.rs
+++ b/sdk/src/jumbf_io.rs
@@ -74,6 +74,19 @@ static BMFF_TYPES: [&str; 12] = [
     "video/mp4",
 ];
 
+#[cfg(all(feature = "otf", feature = "file_io"))]
+static FONT_TYPES: [&str; 4] = [
+    "otf",
+    "ttf",
+    "application/font-sfnt",
+    "font/ttf",
+];
+
+#[cfg(all(feature = "otf", feature = "file_io"))]
+pub(crate) fn is_font_type(asset_type: &str) -> bool {
+    FONT_TYPES.contains(&asset_type)
+}
+
 #[cfg(feature = "file_io")]
 pub(crate) fn is_bmff_format(asset_type: &str) -> bool {
     BMFF_TYPES.contains(&asset_type)

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -57,6 +57,12 @@ use crate::{
         object_locations, remove_jumbf_from_file, save_jumbf_to_file,
     },
 };
+#[cfg(all(feature = "otf", feature = "file_io"))]
+use crate:: {
+    jumbf_io::{
+        is_font_type,
+    },
+};
 
 const MANIFEST_STORE_EXT: &str = "c2pa"; // file extension for external manifests
 
@@ -1728,6 +1734,14 @@ impl Store {
             }
         };
 
+        // XMP doesn't make sense in the form of a font file, so we skip the creation of XMP
+        // for fonts
+        let is_font_type = match cfg!(feature = "otf") && cfg!(feature = "file_io") {
+            #[cfg(all(feature = "otf", feature = "file_io"))]
+            true => is_font_type(&ext),
+            _ => false,
+        };
+
         if asset_path != dest_path {
             fs::copy(asset_path, dest_path).map_err(Error::IoError)?;
         }
@@ -1742,8 +1756,10 @@ impl Store {
                 // the class embedded_xmp is not defined so we have to explicitly exclude it from the build
                 #[cfg(feature = "xmp_write")]
                 if let Some(provenance) = self.provenance_path() {
-                    // update XMP info & add xmp hash to provenance claim
-                    embedded_xmp::add_manifest_uri_to_file(dest_path, &provenance)?;
+                    if !is_font_type {
+                        // update XMP info & add xmp hash to provenance claim
+                        embedded_xmp::add_manifest_uri_to_file(dest_path, &provenance)?;
+                    }
                 } else {
                     return Err(Error::XmpWriteError);
                 }
@@ -1759,7 +1775,7 @@ impl Store {
                 }
             }
             crate::claim::RemoteManifest::Remote(_url) => {
-                if cfg!(feature = "xmp_write") {
+                if cfg!(feature = "xmp_write") && !is_font_type {
                     let d = dest_path.with_extension(MANIFEST_STORE_EXT);
                     // remove any previous c2pa manifest from the asset
                     remove_jumbf_from_file(dest_path)?;
@@ -1773,7 +1789,7 @@ impl Store {
                 }
             }
             crate::claim::RemoteManifest::EmbedWithRemote(_url) => {
-                if cfg!(feature = "xmp_write") {
+                if cfg!(feature = "xmp_write") && !is_font_type {
                     // even though this block is protected by the outer cfg!(feature = "xmp_write")
                     // the class embedded_xmp is not defined so we have to explicitly exclude it from the build
                     #[cfg(feature = "xmp_write")]

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -1736,6 +1736,9 @@ impl Store {
 
         // XMP doesn't make sense in the form of a font file, so we skip the creation of XMP
         // for fonts
+        // This is temporary and not meant to be final production code, we plan to work
+        // on abstracting the writing/reading of the remote manifest URI at some other
+        // point.
         let is_font_type = match cfg!(feature = "otf") && cfg!(feature = "file_io") {
             #[cfg(all(feature = "otf", feature = "file_io"))]
             true => is_font_type(&ext),
@@ -1784,6 +1787,8 @@ impl Store {
                     #[cfg(feature = "xmp_write")]
                     embedded_xmp::add_manifest_uri_to_file(dest_path, &_url)?;
                     d
+                } else if is_font_type {
+                    return Err(Error::RemoteManifestNotSupported);
                 } else {
                     return Err(Error::BadParam("requires 'xmp_write' feature".to_string()));
                 }
@@ -1796,6 +1801,8 @@ impl Store {
                     embedded_xmp::add_manifest_uri_to_file(dest_path, &_url)?;
 
                     dest_path.to_path_buf()
+                } else if is_font_type {
+                    return Err(Error::RemoteManifestNotSupported);
                 } else {
                     return Err(Error::BadParam("requires 'xmp_write' feature".to_string()));
                 }


### PR DESCRIPTION
## Changes in this pull request


The way the c2pa-rs/sdk is configured, the `Store` uses the `jumbf_io` module for doing all of the asset IO for reading/writing the C2PA manifest store, including embedding in the asset. The current `monotype/fontSupport` handles this basic support, as long as `xmp_write` feature is not enabled.  The `xmp_write` is currently a requirement for using:

- `claim::RemoteManifest::EmbedWithRemote` - which assumes the asset uses XMP to embed a URI referencing a remote manifest store and embeds the C2PA manifest store in the asset.
- `claim::RemoteManifest::Remote` - which assumes the asset uses XMP to embed a URI referencing a remote manifest store and does NOT embed the store in the asset.

The code in this PR allows for the use of the `xmp_write` partially for fonts while still fully supporting for the original asset types. With this PR one should be able to use the SDK to embed a C2PA manifest store in a font, but NOT use remote references at this time.  An attempt to use a remote reference will cause a new error to occur `error::Error::RemoteManifestNotSupported`.

Another aspect to this PR is additional font file extensions and mime-types were added for support.



## Checklist
- [X] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
