### PR TITLE
C2PA-50: Move to using newer rust-font-tools module

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -19,8 +19,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-# TODO: Remove these features, only add_thumbnails
-default = ["add_thumbnails", "otf", "file_io"]
+default = ["add_thumbnails"]
 add_thumbnails = ["image"]
 async_signer = ["async-trait", "file_io"]
 bmff = []

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -86,7 +86,7 @@ url = "2.2.2"
 uuid = { version = "0.8.1", features = ["serde", "v4", "wasm-bindgen"] }
 x509-parser = "0.11.0"
 x509-certificate = "0.12.0"
-fonttools = { version = "0.1.0", optional = true }
+fonttools = { git = "https://github.com/simoncozens/rust-font-tools", branch = "main", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ring = "0.16.20"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -86,7 +86,7 @@ url = "2.2.2"
 uuid = { version = "0.8.1", features = ["serde", "v4", "wasm-bindgen"] }
 x509-parser = "0.11.0"
 x509-certificate = "0.12.0"
-fonttools = { git = "https://github.com/simoncozens/rust-font-tools", branch = "main", optional = true }
+fonttools = { git = "https://github.com/vancejc-mt/rust-font-tools", branch = "issue/22/removeCachedDataIfTableModified", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ring = "0.16.20"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -19,7 +19,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["add_thumbnails"]
+# TODO: Remove these features, only add_thumbnails
+default = ["add_thumbnails", "otf", "file_io"]
 add_thumbnails = ["image"]
 async_signer = ["async-trait", "file_io"]
 bmff = []
@@ -86,7 +87,7 @@ url = "2.2.2"
 uuid = { version = "0.8.1", features = ["serde", "v4", "wasm-bindgen"] }
 x509-parser = "0.11.0"
 x509-certificate = "0.12.0"
-fonttools = { git = "https://github.com/vancejc-mt/rust-font-tools", branch = "issue/22/removeCachedDataIfTableModified", optional = true }
+fonttools = { git = "https://github.com/simoncozens/rust-font-tools", rev = "105436d", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ring = "0.16.20"

--- a/sdk/src/asset_handlers/otf_io.rs
+++ b/sdk/src/asset_handlers/otf_io.rs
@@ -10,7 +10,7 @@
 // implied. See the LICENSE-MIT and LICENSE-APACHE files for the
 // specific language governing permissions and limitations under
 // each license.
-use std::{fs::File, fs::OpenOptions, path::*};
+use std::{fs::File, path::*};
 
 use base64::decode as base64_decode;
 use base64::encode as base64_encode;
@@ -88,24 +88,15 @@ impl CAILoader for OtfIO {
     #[allow(unused_variables)]
     fn read_cai(&self, asset_reader: &mut dyn CAIRead) -> Result<Vec<u8>> {
         let cai_data: Vec<u8> = Vec::new();
-        //let mut font_file: Font = font::load(asset_reader).map_err(|_err| Error::FontLoadError)?;
         let font_file: Font =
             Font::from_reader(asset_reader).map_err(|_err| Error::FontLoadError)?;
 
-        /*
-        if let Table::Name(name_table) = font_file
-            .get_table(NAME_TABLE_TAG)
-            .map_err(|_err| Error::DeserializationError)?
-            .ok_or(Error::NotFound)?
-            */
-        ////////// Jeff: try redoing the above code..
         if font_file.contains_table(NAME_TABLE_TAG) {
             let name_table = font_file
                 .tables
                 .name()
                 .map_err(|_err| Error::DeserializationError)?
                 .ok_or(Error::NotFound)?;
-            ////////////////////////// Jeff: end test
 
             let it = name_table.records.iter();
             for name_table_entry in it {
@@ -171,7 +162,7 @@ impl AssetIO for OtfIO {
     #[allow(unused_variables)]
     fn get_object_locations(&self, asset_path: &Path) -> Result<Vec<HashObjectPositions>> {
         let mut positions: Vec<HashObjectPositions> = Vec::new();
-        /*
+
         let table_header_sz: usize = 12;
         let table_entry_sz: usize = 16;
         // We need to get the offset to the 'nam'e table and exclude the length of it and its data.
@@ -191,7 +182,7 @@ impl AssetIO for OtfIO {
         // Then enumerate over all of the table entries looking for a name table
         for table_slice in tables.chunks_exact(table_entry_sz) {
             // Check for the name table from the tag entry
-            if let NAME_TABLE_TAG = read_u8_4(&table_slice[0..4])? {
+            if NAME_TABLE_TAG.as_bytes() == read_u8_4(&table_slice[0..4])? {
                 // We will need to add a position for the 'name' entry since the
                 // checksum changes.
                 positions.push(HashObjectPositions {
@@ -221,32 +212,28 @@ impl AssetIO for OtfIO {
             }
         }
         Err(Error::NotFound)
-        */
-
-        ///////// Fake returning Okay (from above) - remove this
-        return Ok(positions);
     }
 
     fn remove_cai_store(&self, asset_path: &Path) -> Result<()> {
-        /*
-        let f: File = File::open(asset_path)?;
-        let mut font_file: Font = font::load(&f).map_err(|_err| Error::FontLoadError)?;
+        let mut font_file: Font = Font::load(asset_path).map_err(|_err| Error::FontLoadError)?;
 
-        if let Table::Name(name_table) = font_file
-            .get_table(NAME_TABLE_TAG)
-            .map_err(|_err| Error::DeserializationError)?
-            .ok_or(Error::NotFound)?
-        {
+        if font_file.contains_table(NAME_TABLE_TAG) {
+            let mut name_table = font_file
+                .tables
+                .name()
+                .map_err(|_err| Error::DeserializationError)?
+                .ok_or(Error::NotFound)?;
+
             name_table.records.retain(|x: &NameRecord| {
                 x.encodingID != C2PA_ENCODING_ID
                     && x.languageID != C2PA_LANGUAGE_ID
                     && x.nameID != C2PA_NAME_ID
                     && x.platformID != C2PA_PLATFORM_ID
             });
-            let mut f: File = OpenOptions::new().write(true).open(asset_path)?;
-            font_file.save(&mut f);
+            font_file
+                .save(asset_path)
+                .expect("Unable to save font file")
         }
-        */
 
         Ok(())
     }

--- a/sdk/src/asset_handlers/otf_io.rs
+++ b/sdk/src/asset_handlers/otf_io.rs
@@ -149,6 +149,10 @@ impl AssetIO for OtfIO {
         };
         name_table.records.push(c2pa_name);
 
+        // Re-insert the modified name table, this saves a table without a
+        // raw pointer so he'll actually write out the modified table.
+        font_file.tables.insert(name_table);
+
         font_file
             .save(asset_path)
             .expect("Unable to save font file");
@@ -242,8 +246,11 @@ pub mod tests {
     #[test]
     fn add_cai() {
         let font_path = Path::new("C:/jira/c2pa50_updateFontTools/CultStd.otf");
-        let fake_manifest: [u8; 12] = [0u8; 12];
+        let manifest: [u8; 12] = [0u8; 12];
         let otf_io = OtfIO {};
-        otf_io.save_cai_store(&font_path, &fake_manifest).ok();
+        otf_io.save_cai_store(&font_path, &manifest).ok();
+        let parsed_manifest = otf_io.read_cai_store(&font_path).unwrap();
+        let parsed_manifest_slice = parsed_manifest.as_slice();
+        assert_eq!(manifest, parsed_manifest_slice);
     }
 }

--- a/sdk/src/asset_handlers/otf_io.rs
+++ b/sdk/src/asset_handlers/otf_io.rs
@@ -158,7 +158,7 @@ impl AssetIO for OtfIO {
         // Save back to the original file.
         font_file
             .save(asset_path)
-            .expect("Unable to save font file");
+            .map_err(|_err| Error::FontSaveError)?;
 
         Ok(())
     }
@@ -236,7 +236,7 @@ impl AssetIO for OtfIO {
         // Write out modified font.
         font_file
             .save(asset_path)
-            .expect("Unable to save font file");
+            .map_err(|_err| Error::FontSaveError)?;
 
         Ok(())
     }

--- a/sdk/src/asset_handlers/otf_io.rs
+++ b/sdk/src/asset_handlers/otf_io.rs
@@ -148,6 +148,7 @@ impl AssetIO for OtfIO {
             string: base64_encode(store_bytes),
         };
         name_table.records.push(c2pa_name);
+
         font_file
             .save(asset_path)
             .expect("Unable to save font file");
@@ -231,5 +232,18 @@ impl AssetIO for OtfIO {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn add_cai() {
+        let font_path = Path::new("C:/jira/c2pa50_updateFontTools/CultStd.otf");
+        let fake_manifest: [u8; 12] = [0u8; 12];
+        let otf_io = OtfIO {};
+        otf_io.save_cai_store(&font_path, &fake_manifest).ok();
     }
 }

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -260,6 +260,10 @@ pub enum Error {
     #[error("Failed to load font")]
     FontLoadError,
 
+    /// Failed to save a font
+    #[error("Failed to save font")]
+    FontSaveError,
+
     /// Failed to parse or de-serialize font data
     #[error("Failed to de-serialize data")]
     DeserializationError,


### PR DESCRIPTION
## JIRA Link

- https://monotype.atlassian.net/browse/C2PA-50

## Changes in this pull request

Moves the `fonttools` dependency to be based on the top-level `main` branch of the [rust-font-tools](https://github.com/simoncozens/rust-font-tools) repository.  Previously we were using a very old crate of the `v0.1.0` version.

The newer version had a lot of restructuring done, so we needed to massage our code in order to fit.

## Verification

Within `otf_io.rs` there is a single unit test - `add_cai()` - which will exercise the code on any existing .otf font.  To run it:
- Uncomment out the unit test
- Modify the path in the unit test to point to a .otf font local to your machine
- Modify `sdk/Cargo.toml`'s `[features]` default to include the `otf` and `file_io` features:
  - `default = ["add_thumbnails", "otf", "file_io"]`
- Build the SDK
  - `cargo build`
- If you have the `rust-analyzer` VS Code extension, the unit test will have `Run test | debug test` links right above it which will let you run the unit test
## Checklist
- [x] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.

> Actively maintained by the @Monotype/driverpdldev team.
