### PR TITLE
C2PA-95: Temp pseudo XMP support

### DIFF
--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -407,7 +407,8 @@ impl Ingredient {
             "ogg" => "audio/ogg",
             "pdf" => "application/pdf",
             "ai" => "application/postscript",
-            "ttf" | "otf" => "application/font-sfnt",
+            "otf" => "application/x-font-opentype",
+            "ttf" => "application/x-font-truetype",
             _ => "application/octet-stream",
         }
         .to_owned();

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -407,6 +407,7 @@ impl Ingredient {
             "ogg" => "audio/ogg",
             "pdf" => "application/pdf",
             "ai" => "application/postscript",
+            "ttf" | "otf" => "application/font-sfnt",
             _ => "application/octet-stream",
         }
         .to_owned();


### PR DESCRIPTION
<!--  Title should use the format: "JIRA-123: Summary of change"   -->
<!--     Branch names for Stories: "feature/JIRA-123/featureName"  -->
<!--        Branch names for Bugs: "fix/JIRA-123/bugFixName"       -->
# JIRA Issue

- https://monotype.atlassian.net/browse/C2PA-95

# Checklist
<!--  Replace the ' ' with an 'x' for each that applies:  -->
- [x] **PR labeled** appropriately
- [ ] **Documentation** updated:
  - [ ] Developer documentation (ReadMe files)
  - [ ] Product documentation (Release notes, PDK Guide, Functional Spec, API documents, ...)
- [X] **Test case(s)** added
  - [X] Unit Tests

# Notes for Reviewers

Since this is supposed to be temporary, I added a new module, `font_xmp_support`, which contains the necessary functions to read a font as an ingredient.

When signing a font initially the `instance_id` returned in the report will NOT match the instance_id that is used when using remote manifests. But if you run `c2patool --ingredient font.signed.otf` multiple times it will be consistent. I believe this is where we will need to suggest changes to allow for the instance_id the SDK randomly generates is given back to the asset handler to keep track of it going forward.

<!--  Information to assist code reviewers:                    -->
<!--    Dependencies or co-reqs (other branches, other repos)  -->
<!--    Limitations and/or breakage.                           -->

# Verification Instructions
<!-- Instructions for checking or testing this change. -->

To test out, you can try the following scenarios:

### Sign Regularly with Embedding

```
# Sign
c2patool font.otf --manifest manifest.json --force --output font.signed.otf
c2patool --detailed font.signed.otf
c2patool --ingredient font.signed.otf
```

### Add a Remote Manifest Reference

```
> c2patool font.otf --manifest manifest.json --force --output font.signed.otf --remote http://localhost:8000/font.signed.c2pa
> c2patool --ingredient font.signed.otf
> c2patool --detailed font.signed.otf
# Should validate successfully, pulling the C2PA manifest from the sidecar

> mv font.signed.c2pa /tmp/font.signed.c2pa
# In another window run `python -m http.server` from the /tmp directory

> c2patool --detailed font.signed.otf
# Should validate successfully, pulling the C2PA manifest from the remote server
```

### Add a Remote Manifest Reference and Embed

```
> c2patool font.otf --manifest manifest.json --force --output font.signed.otf --remote http://localhost:8000/font.signed.c2pa --sidecar
> c2patool --ingredient font.signed.otf
> c2patool --detailed font.signed.otf
# Should validate successfully, pulling the C2PA manifest from the sidecar

> mv font.signed.c2pa /tmp/font.signed.c2pa
# In this instance, do not start a server to host the file

> c2patool --detailed font.signed.otf
# Should validate successfully, pulling the C2PA manifest from the asset itself
```

> Actively maintained by the @Monotype/driverpdldev team.
