### PR TITLE
C2PA-137: Duplicate mime-type

### DIFF
--- a/sdk/src/asset_handlers/otf_io.rs
+++ b/sdk/src/asset_handlers/otf_io.rs
@@ -275,7 +275,7 @@ static SUPPORTED_TYPES: [&str; 10] = [
     "application/x-font-truetype",
     "font/otf",
     "font/sfnt",
-    "font/otf",
+    "font/ttf",
     "otf",
     "sfnt",
     "ttf",


### PR DESCRIPTION
<!--  Title should use the format: "JIRA-123: Summary of change"   -->
<!--     Branch names for Stories: "feature/JIRA-123/featureName"  -->
<!--        Branch names for Bugs: "fix/JIRA-123/bugFixName"       -->
# JIRA Issue

- C2PA-137

# Checklist
<!--  Replace the ' ' with an 'x' for each that applies:  -->
- [x] **PR labeled** appropriately
- [ ] **Documentation** updated:
  - [ ] Developer documentation (ReadMe files)
  - [ ] Product documentation (Release notes, PDK Guide, Functional Spec, API documents, ...)
- [ ] **Test case(s)** added
  - [ ] Unit Tests

# Notes for Reviewers

I had a typo on the mime-types, had two `font/otf` and missing `font/ttf`. This addresses that issue.

<!--  Information to assist code reviewers:                    -->
<!--    Dependencies or co-reqs (other branches, other repos)  -->
<!--    Limitations and/or breakage.                           -->

# Verification Instructions
<!-- Instructions for checking or testing this change. -->

Should be able to use mimetype `font/ttf` when verifying with the `c2pa-js` with font support. Can use https://github.com/Monotype/c2pa-js/pull/2 to verify .

> Actively maintained by the @Monotype/driverpdldev team.
