### PR TITLE
C2PA-147: General box hashes for fonts

### DIFF
--- a/sdk/src/assertions/box_hash.rs
+++ b/sdk/src/assertions/box_hash.rs
@@ -306,6 +306,29 @@ mod tests {
     use super::*;
     use crate::{jumbf_io::get_assetio_handler_from_path, utils::test::fixture_path};
 
+    #[cfg(feature = "otf")]
+    #[test]
+    fn test_hash_verify_otf() {
+        let ap = fixture_path("font.otf");
+
+        let bhp = get_assetio_handler_from_path(&ap)
+            .unwrap()
+            .asset_box_hash_ref()
+            .unwrap();
+
+        let mut input = File::open(&ap).unwrap();
+
+        let mut bh = BoxHash { boxes: Vec::new() };
+
+        // generate box hashes
+        bh.generate_box_hash_from_stream(&mut input, "sha256", bhp, false)
+            .unwrap();
+
+        // see if they match reading
+        bh.verify_stream_hash(&mut input, Some("sha256"), bhp)
+            .unwrap();
+    }
+
     #[test]
     fn test_hash_verify_jpg() {
         let ap = fixture_path("CA.jpg");

--- a/sdk/src/asset_handlers/otf_io.rs
+++ b/sdk/src/asset_handlers/otf_io.rs
@@ -287,7 +287,7 @@ static SUPPORTED_TYPES: [&str; 10] = [
 const C2PA_TABLE_TAG: Tag = tables::C2PA::TAG;
 /// Tag for the 'head' table in a font.
 const HEAD_TABLE_TAG: Tag = tables::head::TAG;
-/// Lenght of the table directory header (i.e., before the table records)
+/// Length of the table directory header (i.e., before the table records)
 const TABLE_DIRECTORY_HEADER_LENGTH: u32 = 12;
 
 /// Various valid version tags seen in a OTF/TTF file.

--- a/sdk/src/asset_handlers/otf_io.rs
+++ b/sdk/src/asset_handlers/otf_io.rs
@@ -1221,6 +1221,27 @@ pub mod tests {
         assert_eq!(1, table.length);
     }
 
+    #[test]
+    fn get_object_locations() {
+        // Load the basic OTF test fixture
+        let source = fixture_path("font.otf");
+
+        // Create a temporary output for the file
+        let temp_dir = tempdir().unwrap();
+        let output = temp_dir_path(&temp_dir, "test.otf");
+
+        // Copy the source to the output
+        std::fs::copy(source, &output).unwrap();
+
+        // Create our OtfIO asset handler for testing
+        let otf_io = OtfIO {};
+        // The font has 11 records, 11 tables, 1 table directory
+        // but the head table will expand from 1 to 3 positions bringing it to 25
+        // And then the required C2PA chunks will be added, bringing it to 27
+        let object_positions = otf_io.get_object_locations(&output).unwrap();
+        assert_eq!(27, object_positions.len());
+    }
+
     /// Verify the C2PA table data can be read from a font stream
     #[test]
     fn reads_c2pa_table_from_stream() {

--- a/sdk/src/asset_handlers/otf_io.rs
+++ b/sdk/src/asset_handlers/otf_io.rs
@@ -1174,7 +1174,8 @@ pub mod tests {
             0x00, 0x00, // 0 tables
         ];
         let mut font_stream: Cursor<&[u8]> = Cursor::<&[u8]>::new(&font_data);
-        let positions = get_object_locations_from_stream(&mut font_stream).unwrap();
+        let otf_io = OtfIO {};
+        let positions = get_object_locations_from_stream(&otf_io, &mut font_stream).unwrap();
         // Should have one position reported for the entire "file"
         assert_eq!(1, positions.len());
         assert_eq!(12, positions.get(0).unwrap().offset);
@@ -1198,7 +1199,8 @@ pub mod tests {
             0x00, // C2PB data
         ];
         let mut font_stream: Cursor<&[u8]> = Cursor::<&[u8]>::new(&font_data);
-        let positions = get_object_locations_from_stream(&mut font_stream).unwrap();
+        let otf_io = OtfIO {};
+        let positions = get_object_locations_from_stream(&otf_io, &mut font_stream).unwrap();
         // Should have one position reported for the table directory
         assert_eq!(1, positions.len());
         assert_eq!(12, positions.get(0).unwrap().offset);
@@ -1228,7 +1230,8 @@ pub mod tests {
             0x66, 0x69, 0x6c, 0x65, 0x3a, 0x2f, 0x2f, 0x61, // active manifest uri data
         ];
         let mut font_stream: Cursor<&[u8]> = Cursor::<&[u8]>::new(&font_data);
-        let positions = get_object_locations_from_stream(&mut font_stream).unwrap();
+        let otf_io = OtfIO {};
+        let positions = get_object_locations_from_stream(&otf_io, &mut font_stream).unwrap();
         // Should have 3 positions reported
         assert_eq!(3, positions.len());
         // The first one is the position to the table header entry which describes where
@@ -1274,7 +1277,8 @@ pub mod tests {
             0x00, 0x00, 0x00, 0x00, // checksumAdjustment
         ];
         let mut font_stream: Cursor<&[u8]> = Cursor::<&[u8]>::new(&font_data);
-        let positions = get_object_locations_from_stream(&mut font_stream).unwrap();
+        let otf_io = OtfIO {};
+        let positions = get_object_locations_from_stream(&otf_io, &mut font_stream).unwrap();
         // Should have 4 positions reported
         assert_eq!(4, positions.len());
         // The first one is the position to the table header entry which describes where

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -1431,50 +1431,104 @@ impl Store {
         // sort blocks by offset
         block_locations.sort_by(|a, b| a.offset.cmp(&b.offset));
 
-        // generate default data hash that excludes jumbf block
-        // find the first jumbf block (ours are always in order)
-        // find the first block after the jumbf blocks
-        let mut block_start: usize = 0;
-        let mut block_end: usize = 0;
-        let mut found_jumbf = false;
-        for item in block_locations {
-            // find start of jumbf
-            if !found_jumbf && item.htype == HashBlockObjectType::Cai {
-                block_start = item.offset;
-                found_jumbf = true;
+        // For font support, we must specialize the exclusions as the C2PA data
+        // is split into two different areas:
+        //
+        // 1. The table directory record item
+        // 2. The table data
+        //
+        // Once true support for TIFF general boxes go in, this should change
+        // quite a bit to allow for a similar structure, so this code is
+        // considered temporary. It is put within a feature flag to allow for
+        // easy removal.
+        #[cfg(feature = "otf")]
+        {
+            // Setup to assume fragmented CAI blocks
+            let mut exclusions = Vec::new();
+            for item in block_locations {
+                // find start of jumbf
+                if item.htype == HashBlockObjectType::Cai {
+                    // Make sure we have a valid range
+                    if item.offset < (item.offset + item.length) {
+                        exclusions.push((item.offset, item.offset + item.length));
+                    }
+                }
             }
 
-            // find start of block after jumbf blocks
-            if found_jumbf && item.htype == HashBlockObjectType::Cai {
-                block_end = item.offset + item.length;
+            if !exclusions.is_empty() {
+                // add exclusion hash for bytes before and after jumbf
+                let mut dh = DataHash::new("jumbf manifest", alg);
+                for exclusion in &exclusions {
+                    dh.add_exclusion(HashRange::new(exclusion.0, exclusion.1 - exclusion.0));
+                }
+
+                if calc_hashes {
+                    // this check is only valid on the final sized asset
+                    if exclusions.iter().any(|x| x.1 as u64 > stream_len) {
+                        return Err(Error::BadParam(
+                            "data hash exclusions out of range".to_string(),
+                        ));
+                    }
+
+                    dh.gen_hash_from_stream(stream)?;
+                } else {
+                    match alg {
+                        "sha256" => dh.set_hash([0u8; 32].to_vec()),
+                        "sha384" => dh.set_hash([0u8; 48].to_vec()),
+                        "sha512" => dh.set_hash([0u8; 64].to_vec()),
+                        _ => return Err(Error::UnsupportedType),
+                    }
+                }
+                hashes.push(dh);
             }
         }
-
-        if found_jumbf {
-            // add exclusion hash for bytes before and after jumbf
-            let mut dh = DataHash::new("jumbf manifest", alg);
-            if block_end > block_start {
-                dh.add_exclusion(HashRange::new(block_start, block_end - block_start));
-            }
-
-            if calc_hashes {
-                // this check is only valid on the final sized asset
-                if block_end as u64 > stream_len {
-                    return Err(Error::BadParam(
-                        "data hash exclusions out of range".to_string(),
-                    ));
+        #[cfg(not(feature = "otf"))]
+        {
+            // generate default data hash that excludes jumbf block
+            // find the first jumbf block (ours are always in order)
+            // find the first block after the jumbf blocks
+            let mut block_start: usize = 0;
+            let mut block_end: usize = 0;
+            let mut found_jumbf = false;
+            for item in block_locations {
+                // find start of jumbf
+                if !found_jumbf && item.htype == HashBlockObjectType::Cai {
+                    block_start = item.offset;
+                    found_jumbf = true;
                 }
 
-                dh.gen_hash_from_stream(stream)?;
-            } else {
-                match alg {
-                    "sha256" => dh.set_hash([0u8; 32].to_vec()),
-                    "sha384" => dh.set_hash([0u8; 48].to_vec()),
-                    "sha512" => dh.set_hash([0u8; 64].to_vec()),
-                    _ => return Err(Error::UnsupportedType),
+                // find start of block after jumbf blocks
+                if found_jumbf && item.htype == HashBlockObjectType::Cai {
+                    block_end = item.offset + item.length;
                 }
             }
-            hashes.push(dh);
+
+            if found_jumbf {
+                // add exclusion hash for bytes before and after jumbf
+                let mut dh = DataHash::new("jumbf manifest", alg);
+                if block_end > block_start {
+                    dh.add_exclusion(HashRange::new(block_start, block_end - block_start));
+                }
+
+                if calc_hashes {
+                    // this check is only valid on the final sized asset
+                    if block_end as u64 > stream_len {
+                        return Err(Error::BadParam(
+                            "data hash exclusions out of range".to_string(),
+                        ));
+                    }
+
+                    dh.gen_hash_from_stream(stream)?;
+                } else {
+                    match alg {
+                        "sha256" => dh.set_hash([0u8; 32].to_vec()),
+                        "sha384" => dh.set_hash([0u8; 48].to_vec()),
+                        "sha512" => dh.set_hash([0u8; 64].to_vec()),
+                        _ => return Err(Error::UnsupportedType),
+                    }
+                }
+                hashes.push(dh);
+            }
         }
 
         Ok(hashes)

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -1449,7 +1449,7 @@ impl Store {
                 // find start of jumbf
                 if item.htype == HashBlockObjectType::Cai {
                     // Make sure we have a valid range
-                    if item.offset < (item.offset + item.length) {
+                    if item.offset <= (item.offset + item.length) {
                         let mut exclusion = (item.offset, item.offset + item.length);
                         // Setup to defragment sections that are contiguous but may have
                         // been listed as separate
@@ -1470,7 +1470,9 @@ impl Store {
                 // add exclusion hash for bytes before and after jumbf
                 let mut dh = DataHash::new("jumbf manifest", alg);
                 for exclusion in &exclusions {
-                    dh.add_exclusion(HashRange::new(exclusion.0, exclusion.1 - exclusion.0));
+                    if exclusion.1 > exclusion.0 {
+                        dh.add_exclusion(HashRange::new(exclusion.0, exclusion.1 - exclusion.0));
+                    }
                 }
 
                 if calc_hashes {


### PR DESCRIPTION
<!--  Title should use the format: "JIRA-123: Summary of change"   -->
<!--     Branch names for Stories: "feature/JIRA-123/featureName"  -->
<!--        Branch names for Bugs: "fix/JIRA-123/bugFixName"       -->
# JIRA Issue

- C2PA-147

# Checklist
<!--  Replace the ' ' with an 'x' for each that applies:  -->
- [x] **PR labeled** appropriately
- [ ] **Documentation** updated:
  - [ ] Developer documentation (ReadMe files)
  - [ ] Product documentation (Release notes, PDK Guide, Functional Spec, API documents, ...)
- [X] **Test case(s)** added
  - [X] Unit Tests

# Notes for Reviewers

Although general box hash support was added to the SDK, I found no code other than integration tests calling the new `AssetBoxHash` trait on asset IO handlers. 

With that said, the way chunks/positions were read from fonts were redone to use a trait for abstraction at a later point for other font formats.

One of the more controversial changes is to the `store.rs` module. I added the ability to add multiple exclusions for the data hashing, defragmenting locations when they were actually contiguous data but listed separately. The defragmenting mimics what the SDK was doing and I noticed it during JPEG handling. Regardless, I protected my changes with a `#[cfg(feature = "otf")]` to help keep up with what was original and what I added.


<!--  Information to assist code reviewers:                    -->
<!--    Dependencies or co-reqs (other branches, other repos)  -->
<!--    Limitations and/or breakage.                           -->

# Verification Instructions
<!-- Instructions for checking or testing this change. -->

Use the c2patool changes from https://github.com/Monotype/c2patool/pull/9  to verify font hashing has improved:

- Should be able to sign a font and muck with the font and have it where the validation states it is not valid
    - > NOTE: this was not the case before cause the SDK would glob all data in between CAI records as one, assuming the jumbf blocks were all next to each other

Since I mucked with code outside of the `otf_io` handler, verify you can still sign/validate a JPEG and/or PNG.

> Actively maintained by the @Monotype/driverpdldev team.
