### PR TITLE
Restore rewinding the stream when getting object locations.

### DIFF
--- a/sdk/src/asset_handlers/otf_io.rs
+++ b/sdk/src/asset_handlers/otf_io.rs
@@ -763,6 +763,9 @@ fn get_object_locations_from_stream<T>(
 where
     T: Read + Seek + ?Sized,
 {
+    // The SDK doesn't necessarily promise the input stream is rewound, so do so
+    // now to make sure we can parse the font.
+    reader.rewind()?;
     // We must take into account a font that may not have a C2PA table in it at
     // this point, adding any required chunks needed for C2PA to work correctly.
     let output_vec: Vec<u8> = Vec::new();


### PR DESCRIPTION
<!--  Title should use the format: "JIRA-123: Summary of change"   -->
<!--     Branch names for Stories: "feature/JIRA-123/featureName"  -->
<!--        Branch names for Bugs: "fix/JIRA-123/bugFixName"       -->
# JIRA Issue

- C2PA-250

# Checklist
<!--  Replace the ' ' with an 'x' for each that applies:  -->
- [x] **PR labeled** appropriately
- [ ] **Documentation** updated:
  - [ ] Developer documentation (ReadMe files)
  - [ ] Product documentation (Release notes, PDK Guide, Functional Spec, API documents, ...)
- [ ] **Test case(s)** added
  - [ ] Unit Tests

# Notes for Reviewers

This fixes a regression issue. When implementing the general box hashes I accidentally removed a rewind on the input stream for the objection locations function. This PR restores that rewind.

<!--  Information to assist code reviewers:                    -->
<!--    Dependencies or co-reqs (other branches, other repos)  -->
<!--    Limitations and/or breakage.                           -->

# Verification Instructions
<!-- Instructions for checking or testing this change. -->

Should still be able to use the tool to sign fonts.

> Actively maintained by the @Monotype/driverpdldev team.
