### PR TITLE
C2PA-272: Sync with upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,6 +307,6 @@ jobs:
           VERSION: ${{ steps.set-version.outputs.version }}
 
       - name: If this step fails, change title of the PR to include (MINOR) tag
-        uses: obi1kenobi/cargo-semver-checks-action@v1
+        uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
-          crate-name: c2pa
+          package: c2pa

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,21 +246,6 @@ jobs:
           version: latest
           args: --all-targets --all-features
 
-  unknown-features-cfg:
-    name: Check for unknown features in cfg attributes and macros
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
-
-      - name: Check for unknown features
-        env:
-          RUSTFLAGS: "-D unexpected-cfgs"
-        run: cargo +nightly check -Z unstable-options -Z check-cfg=features --tests
-
   version_bump:
     name: Ensure (MINOR) tag is used when making an API breaking change
     # Change all of these steps to (MAJOR) after 1.0 release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,9 +88,9 @@ jobs:
         commit_user_email: noreply@adobe.com
 
     - name: Ensure semantic versioning requirements are met
-      uses: obi1kenobi/cargo-semver-checks-action@v1
+      uses: obi1kenobi/cargo-semver-checks-action@v2
       with:
-        crate-name: c2pa
+        package: c2pa
 
     - name: Create release
       uses: ncipollo/release-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Cargo.lock
 
 .vscode
 
+/semver-checks/target/

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ check-docs:
 	cargo doc --no-deps --workspace --all-features
 
 clippy:
-	cargo clippy --all-features --all-targets -- -D warnings
+	cargo +nightly clippy --all-features --all-targets -- -D warnings
 
 test-local:
 	cargo test --all-features

--- a/export_schema/Cargo.toml
+++ b/export_schema/Cargo.toml
@@ -9,5 +9,5 @@ rust-version = "1.70.0"
 [dependencies]
 anyhow = "1.0.40"
 c2pa = { path = "../sdk", features = ["file_io", "json_schema"] }
-schemars = "0.8.12"
+schemars = "0.8.13"
 serde_json = "1.0.81"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -89,7 +89,7 @@ png_pong = "0.8.2"
 range-set = "0.0.9"
 ring = "0.16.20"
 riff = "1.0.1"
-schemars = { version = "0.8.12", optional = true }
+schemars = { version = "0.8.13", optional = true }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_bytes = "0.11.5"
 serde_cbor = "0.11.1"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -108,7 +108,7 @@ url = "2.2.2"
 uuid = { version = "1.3.1", features = ["serde", "v4", "wasm-bindgen"] }
 x509-parser = "0.15.0"
 x509-certificate = "0.19.0"
-fonttools = { git = "https://github.com/Monotype/rust-font-tools", branch="feature/C2PA-272/catchUp", optional = true }
+fonttools = { git = "https://github.com/Monotype/rust-font-tools", branch="monotype/fontSupport", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ureq = "2.4.0"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -108,7 +108,7 @@ url = "2.2.2"
 uuid = { version = "1.3.1", features = ["serde", "v4", "wasm-bindgen"] }
 x509-parser = "0.15.0"
 x509-certificate = "0.19.0"
-fonttools = { git = "https://github.com/Monotype/rust-font-tools", branch="monotype/fontSupport", optional = true }
+fonttools = { git = "https://github.com/Monotype/rust-font-tools", branch="feature/C2PA-272/catchUp", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ureq = "2.4.0"

--- a/sdk/src/asn1/rfc3281.rs
+++ b/sdk/src/asn1/rfc3281.rs
@@ -69,7 +69,7 @@ pub struct AttributeCertificateInfo {
 }
 
 impl AttributeCertificateInfo {
-    pub fn take_from<S: Source>(cons: &mut Constructed<S>) -> Result<Self, DecodeError<S::Error>> {
+    pub fn take_from<S: Source>(cons: &Constructed<S>) -> Result<Self, DecodeError<S::Error>> {
         Err(cons.content_err("AttributeCertificateInfo parsing not implemented"))
     }
 }

--- a/sdk/src/asn1/rfc5652.rs
+++ b/sdk/src/asn1/rfc5652.rs
@@ -159,7 +159,7 @@ pub struct SignedData {
 impl SignedData {
     /// Attempt to decode BER encoded bytes to a parsed data structure.
     pub fn decode_ber(data: &[u8]) -> Result<Self, DecodeError<std::convert::Infallible>> {
-        Constructed::decode(data, bcder::Mode::Ber, |cons| Self::decode(cons))
+        Constructed::decode(data, bcder::Mode::Ber, Self::decode)
     }
 
     pub fn decode<S: Source>(cons: &mut Constructed<S>) -> Result<Self, DecodeError<S::Error>> {
@@ -1118,7 +1118,7 @@ pub type KeyDerivationAlgorithmIdentifier = AlgorithmIdentifier;
 pub struct RevocationInfoChoices(Vec<RevocationInfoChoice>);
 
 impl RevocationInfoChoices {
-    pub fn take_from<S: Source>(cons: &mut Constructed<S>) -> Result<Self, DecodeError<S::Error>> {
+    pub fn take_from<S: Source>(cons: &Constructed<S>) -> Result<Self, DecodeError<S::Error>> {
         Err(cons.content_err("RevocationInfoChoices parsing not implemented"))
     }
 }
@@ -1232,7 +1232,7 @@ pub struct OtherCertificateFormat {
 }
 
 impl OtherCertificateFormat {
-    pub fn take_from<S: Source>(cons: &mut Constructed<S>) -> Result<Self, DecodeError<S::Error>> {
+    pub fn take_from<S: Source>(cons: &Constructed<S>) -> Result<Self, DecodeError<S::Error>> {
         Err(cons.content_err("OtherCertificateFormat parsing not implemented"))
     }
 }

--- a/sdk/src/assertions/ingredient.rs
+++ b/sdk/src/assertions/ingredient.rs
@@ -124,7 +124,7 @@ impl Ingredient {
     }
 
     pub fn add_review(mut self, review: ReviewRating) -> Self {
-        let metadata = self.metadata.unwrap_or_else(Metadata::new);
+        let metadata = self.metadata.unwrap_or_default();
         self.metadata = Some(metadata.add_review(review));
         self
     }

--- a/sdk/src/asset_handlers/bmff_io.rs
+++ b/sdk/src/asset_handlers/bmff_io.rs
@@ -354,7 +354,7 @@ fn add_token_to_cache(bmff_path_map: &mut HashMap<String, Vec<Token>>, path: Str
     }
 }
 
-fn path_from_token(bmff_tree: &mut Arena<BoxInfo>, current_node_token: &Token) -> Result<String> {
+fn path_from_token(bmff_tree: &Arena<BoxInfo>, current_node_token: &Token) -> Result<String> {
     let ancestors = current_node_token.ancestors(bmff_tree);
     let mut path = bmff_tree[*current_node_token].data.path.clone();
 

--- a/sdk/src/asset_handlers/tiff_io.rs
+++ b/sdk/src/asset_handlers/tiff_io.rs
@@ -863,7 +863,7 @@ impl<T: Read + Write + Seek> TiffCloner<T> {
 
     fn clone_sub_files<R: Read + Seek>(
         &mut self,
-        tiff_tree: &mut Arena<ImageFileDirectory>,
+        tiff_tree: &Arena<ImageFileDirectory>,
         page: Token,
         asset_reader: &mut R,
     ) -> Result<HashMap<u16, Vec<u64>>> {

--- a/sdk/src/asset_handlers/woff_io.rs
+++ b/sdk/src/asset_handlers/woff_io.rs
@@ -808,17 +808,23 @@ impl Font {
             reader.seek(SeekFrom::Start(wtde.offset as u64))?;
             reader.read_exact(&mut table_data)?;
 
-            let table: Table = {
-                match wtde.tag {
-                    //C2PA_TABLE_TAG => {
-                    //    Table::C2PA({tbl: }) {}
-                    //}
-                    //HEAD_TABLE_TAG => {
-                    //    Table::Head(TableHead) {}
-                    //}
-                    _ => Table::Unspecified(TableUnspecified { data: table_data }),
-                }
-            };
+            // For now, just make an Unspecified table
+            let table: Table = Table::Unspecified(TableUnspecified { data: table_data });
+
+            // But someday, key off the tag & create specialized instances for
+            // certain tables, like so:
+            //
+            //     let table: Table = {
+            //         match wtde.tag {
+            //             C2PA_TABLE_TAG => {
+            //                 Table::C2PA({tbl: }) {}
+            //             }
+            //             HEAD_TABLE_TAG => {
+            //                 Table::Head(TableHead) {}
+            //             }
+            //             _ => Table::Unspecified(...);
+            //         }
+            //     };
 
             // Store it in the bucket
             the_font.tables.insert(wtde.tag, table);

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -702,7 +702,7 @@ impl Claim {
         let mut databox_uri = C2PAAssertion::new(link, Some(self.alg().to_string()), &hash);
         databox_uri.add_salt(salt);
 
-        // add credential to vcstore
+        // add databox to databox store
         self.data_boxes.push((databox_uri.clone(), new_db));
 
         Ok(databox_uri)

--- a/sdk/src/claim.rs
+++ b/sdk/src/claim.rs
@@ -855,94 +855,92 @@ impl Claim {
         self.assertion_store.push(assertion);
     }
 
-    // crate private function to allow for patching a data hash with final contents
-    pub(crate) fn update_data_hash(&mut self, mut data_hash: DataHash) -> Result<()> {
-        let mut replacement_assertion = data_hash.to_assertion()?;
+    // Patch an existing assertion with new contents.
+    //
+    // `replace_with` should match in name and size of an existing assertion.
+    fn update_assertion<MatchFn, PatchFn>(
+        &mut self,
+        replace_with: Assertion,
+        match_fn: MatchFn,
+        patch_fn: PatchFn,
+    ) -> Result<()>
+    where
+        MatchFn: Fn(&ClaimAssertion) -> bool,
+        PatchFn: FnOnce(&ClaimAssertion, Assertion) -> Result<Assertion>,
+    {
+        // Find the assertion that should be replaced.
+        let Some(ref mut target_assertion) = self
+            .assertion_store
+            .iter_mut()
+            .find(|ca| Assertion::assertions_eq(&replace_with, ca.assertion()) && match_fn(ca))
+        else {
+            return Err(Error::NotFound);
+        };
 
-        match self.assertion_store.iter_mut().find(|assertion| {
-            // is this a DataHash Assertion
-            if !Assertion::assertions_eq(&replacement_assertion, assertion.assertion()) {
-                return false;
-            }
+        // Save off copy of original hash to cross-check before
+        // replacing it.
+        let original_hash = target_assertion.hash().to_vec();
 
-            if let Ok(dh) = DataHash::from_assertion(assertion.assertion()) {
-                dh.name == data_hash.name
-            } else {
-                false
-            }
-        }) {
-            Some(ref mut dh_assertion) => {
-                let original_hash = dh_assertion.hash().to_vec();
-                let original_len = dh_assertion.assertion().data().len();
-                data_hash.pad_to_size(original_len)?;
-                replacement_assertion = data_hash.to_assertion()?;
+        // Give caller a chance to patch/replace the assertion.
+        let replace_with = patch_fn(target_assertion, replace_with)?;
 
-                let replacement_hash = Claim::calc_assertion_box_hash(
-                    &dh_assertion.label(),
-                    &replacement_assertion,
-                    dh_assertion.salt().clone(),
-                    dh_assertion.hash_alg(),
-                )?;
-                dh_assertion.update_assertion(replacement_assertion, replacement_hash)?;
+        // Calculate new hash, given new content.
+        let replacement_hash = Claim::calc_assertion_box_hash(
+            &target_assertion.label(),
+            &replace_with,
+            target_assertion.salt().clone(),
+            target_assertion.hash_alg(),
+        )?;
 
-                // fix up hashed uri
-                match self.assertions.iter_mut().find_map(|f| {
-                    if f.url().contains(&dh_assertion.label())
-                        && vec_compare(&f.hash(), &original_hash)
-                    {
-                        // replace with newly updated hash
-                        f.update_hash(dh_assertion.hash().to_vec());
-                        Some(f)
-                    } else {
-                        None
-                    }
-                }) {
-                    Some(_) => Ok(()),
-                    None => Err(Error::NotFound),
-                }
-            }
-            None => Err(Error::NotFound),
-        }
+        target_assertion.update_assertion(replace_with, replacement_hash)?;
+
+        let target_label = target_assertion.label();
+        let target_hash = target_assertion.hash();
+
+        // Replace the existing hash in the hashed URI reference
+        // with the newly-calculated hash.
+        let Some(f) = self
+            .assertions
+            .iter_mut()
+            .find(|f| f.url().contains(&target_label) && vec_compare(&f.hash(), &original_hash))
+        else {
+            return Err(Error::NotFound);
+        };
+
+        // Replace existing hash with newly-calculated hash.
+        f.update_hash(target_hash.to_vec());
+        Ok(())
     }
 
-    // crate private function to allow for patching a BMFF hash with final contents
+    // Crate private function to allow for patching a data hash with final contents.
+    pub(crate) fn update_data_hash(&mut self, mut data_hash: DataHash) -> Result<()> {
+        let dh_name = data_hash.name.clone();
+
+        self.update_assertion(
+            data_hash.to_assertion()?,
+            |ca: &ClaimAssertion| {
+                if let Ok(dh) = DataHash::from_assertion(ca.assertion()) {
+                    dh.name == dh_name
+                } else {
+                    false
+                }
+            },
+            |target_assertion: &ClaimAssertion, _: Assertion| {
+                let original_len = target_assertion.assertion().data().len();
+                data_hash.pad_to_size(original_len)?;
+                data_hash.to_assertion()
+            },
+        )
+    }
+
+    // Crate private function to allow for patching a BMFF hash with final contents.
     #[cfg(feature = "file_io")]
     pub(crate) fn update_bmff_hash(&mut self, bmff_hash: BmffHash) -> Result<()> {
-        let replacement_assertion = bmff_hash.to_assertion()?;
-
-        match self.assertion_store.iter_mut().find(|assertion| {
-            // is this a BMFFHash Assertion
-            Assertion::assertions_eq(&replacement_assertion, assertion.assertion())
-        }) {
-            Some(ref mut bmff_assertion) => {
-                let original_hash = bmff_assertion.hash().to_vec();
-
-                let replacement_hash = Claim::calc_assertion_box_hash(
-                    &bmff_assertion.label(),
-                    &replacement_assertion,
-                    bmff_assertion.salt().clone(),
-                    bmff_assertion.hash_alg(),
-                )?;
-                bmff_assertion.update_assertion(replacement_assertion, replacement_hash)?;
-
-                // fix up hashed uri
-                match self.assertions.iter_mut().find_map(|f| {
-                    if f.url().contains(&bmff_assertion.label())
-                        && vec_compare(&f.hash(), &original_hash)
-                    {
-                        // replace with newly updated hash
-                        f.update_hash(bmff_assertion.hash().to_vec());
-                        Some(f)
-                    } else {
-                        None
-                    }
-                }) {
-                    Some(_) => Ok(()),
-                    None => Err(Error::NotFound),
-                }
-            }
-            None => Err(Error::NotFound),
-        }
+        self.update_assertion(
+            bmff_hash.to_assertion()?,
+            |_: &ClaimAssertion| true,
+            |_: &ClaimAssertion, a: Assertion| Ok(a),
+        )
     }
 
     /// Redact an assertion from a prior claim.

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -569,7 +569,7 @@ impl Ingredient {
         &mut self,
         result: Result<Store>,
         manifest_bytes: Option<Vec<u8>>,
-        validation_log: &mut impl StatusTracker,
+        validation_log: &impl StatusTracker,
     ) -> Result<()> {
         match result {
             Ok(store) => {
@@ -736,7 +736,7 @@ impl Ingredient {
         };
 
         // set validation status from result and log
-        ingredient.update_validation_status(result, manifest_bytes, &mut validation_log)?;
+        ingredient.update_validation_status(result, manifest_bytes, &validation_log)?;
 
         // create a thumbnail if we don't already have a manifest with a thumb we can use
         if ingredient.thumbnail.is_none() {
@@ -798,7 +798,7 @@ impl Ingredient {
         };
 
         // set validation status from result and log
-        ingredient.update_validation_status(result, manifest_bytes, &mut validation_log)?;
+        ingredient.update_validation_status(result, manifest_bytes, &validation_log)?;
 
         // create a thumbnail if we don't already have a manifest with a thumb we can use
         #[cfg(feature = "add_thumbnails")]
@@ -871,7 +871,7 @@ impl Ingredient {
         };
 
         // set validation status from result and log
-        ingredient.update_validation_status(result, manifest_bytes, &mut validation_log)?;
+        ingredient.update_validation_status(result, manifest_bytes, &validation_log)?;
 
         // create a thumbnail if we don't already have a manifest with a thumb we can use
         #[cfg(feature = "add_thumbnails")]
@@ -1206,7 +1206,7 @@ impl Ingredient {
         };
 
         // set validation status from result and log
-        ingredient.update_validation_status(result, Some(manifest_bytes), &mut validation_log)?;
+        ingredient.update_validation_status(result, Some(manifest_bytes), &validation_log)?;
 
         // create a thumbnail if we don't already have a manifest with a thumb we can use
         #[cfg(feature = "add_thumbnails")]

--- a/sdk/src/jumbf/labels.rs
+++ b/sdk/src/jumbf/labels.rs
@@ -122,6 +122,17 @@ pub(crate) fn to_normalized_uri(uri: &str) -> String {
     }
 }
 
+// Converts a possibly relative JUMBF URI to an absolute URI to the manifest store.
+pub(crate) fn to_absolute_uri(manifest_label: &str, uri: &str) -> String {
+    let raw_uri = to_normalized_uri(uri);
+    let parts: Vec<&str> = raw_uri.split('/').collect();
+    if parts.len() > 2 && parts[1] == MANIFEST_STORE {
+        uri.to_string()
+    } else {
+        format!("{}/{}", to_manifest_uri(manifest_label), raw_uri)
+    }
+}
+
 // Converts an absolute JUMBF URI to a URI relative to the manifest store.
 pub(crate) fn to_relative_uri(uri: &str) -> String {
     let raw_uri = to_normalized_uri(uri);

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -525,6 +525,7 @@ impl Manifest {
         }
 
         manifest.set_label(claim.label());
+        manifest.resources.set_label(claim.label()); // default manifest for relative urls
         manifest.claim_generator_hints = claim.get_claim_generator_hint_map().cloned();
 
         // get credentials converting from AssertionData to Value
@@ -629,7 +630,13 @@ impl Manifest {
                 }
                 label if label.starts_with(labels::CLAIM_THUMBNAIL) => {
                     let thumbnail = Thumbnail::from_assertion(assertion)?;
-                    manifest.set_thumbnail(thumbnail.content_type, thumbnail.data)?;
+                    let id = jumbf::labels::to_assertion_uri(claim.label(), label);
+                    let id = jumbf::labels::to_relative_uri(&id);
+                    manifest.thumbnail = Some(manifest.resources.add_uri(
+                        &id,
+                        &thumbnail.content_type,
+                        thumbnail.data,
+                    )?);
                 }
                 _ => {
                     // inject assertions for all other assertions

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -1170,7 +1170,8 @@ impl Manifest {
         }
 
         let mut store = self.to_store()?;
-        let placeholder = store.get_data_hashed_manifest_placeholder(signer, format)?;
+        let placeholder =
+            store.get_data_hashed_manifest_placeholder(signer.reserve_size(), format)?;
         Ok(placeholder)
     }
 

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -1023,7 +1023,8 @@ impl Manifest {
     }
 
     /// Embed a signed manifest into a stream using a supplied signer.
-    /// returns the bytes of the new asset
+    ///
+    /// Returns the bytes of the new asset
     #[deprecated(since = "0.27.2", note = "use embed_to_stream instead")]
     pub fn embed_stream(
         &mut self,
@@ -1041,7 +1042,8 @@ impl Manifest {
     }
 
     /// Embed a signed manifest into a stream using a supplied signer.
-    /// returns the bytes of c2pa_manifest that was embedded
+    ///
+    /// Returns the bytes of c2pa_manifest that was embedded.
     pub fn embed_to_stream(
         &mut self,
         format: &str,

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -509,15 +509,10 @@ impl Manifest {
 
         if let Some(info_vec) = claim.claim_generator_info() {
             let mut generators = Vec::new();
-            let id_base = manifest.instance_id().to_owned();
             for claim_info in info_vec {
                 let mut info = claim_info.to_owned();
                 if let Some(icon) = claim_info.icon.as_ref() {
-                    info.set_icon(icon.to_resource_ref(
-                        manifest.resources_mut(),
-                        claim,
-                        &id_base,
-                    )?);
+                    info.set_icon(icon.to_resource_ref(manifest.resources_mut(), claim)?);
                 }
                 generators.push(info);
             }
@@ -565,18 +560,13 @@ impl Manifest {
             match base_label.as_ref() {
                 base if base.starts_with(labels::ACTIONS) => {
                     let mut actions = Actions::from_assertion(assertion)?;
-                    let id = manifest.instance_id().to_owned();
 
                     for action in actions.actions_mut() {
                         if let Some(SoftwareAgent::ClaimGeneratorInfo(info)) =
                             action.software_agent_mut()
                         {
                             if let Some(icon) = info.icon.as_mut() {
-                                let icon = icon.to_resource_ref(
-                                    manifest.resources_mut(),
-                                    claim,
-                                    id.as_str(),
-                                )?;
+                                let icon = icon.to_resource_ref(manifest.resources_mut(), claim)?;
                                 info.set_icon(icon);
                             }
                         }
@@ -587,11 +577,9 @@ impl Manifest {
                         for template in templates {
                             // replace icon with resource ref
                             template.icon = match template.icon.take() {
-                                Some(icon) => Some(icon.to_resource_ref(
-                                    manifest.resources_mut(),
-                                    claim,
-                                    id.as_str(),
-                                )?),
+                                Some(icon) => {
+                                    Some(icon.to_resource_ref(manifest.resources_mut(), claim)?)
+                                }
                                 None => None,
                             };
 
@@ -599,11 +587,8 @@ impl Manifest {
                             template.software_agent = match template.software_agent.take() {
                                 Some(SoftwareAgent::ClaimGeneratorInfo(mut info)) => {
                                     if let Some(icon) = info.icon.as_mut() {
-                                        let icon = icon.to_resource_ref(
-                                            manifest.resources_mut(),
-                                            claim,
-                                            id.as_str(),
-                                        )?;
+                                        let icon =
+                                            icon.to_resource_ref(manifest.resources_mut(), claim)?;
                                         info.set_icon(icon);
                                     }
                                     Some(SoftwareAgent::ClaimGeneratorInfo(info))

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -554,7 +554,10 @@ impl Manifest {
         manifest.set_format(claim.format());
         manifest.set_instance_id(claim.instance_id());
 
-        for claim_assertion in claim.claim_assertion_store().iter() {
+        for assertion in claim.assertions() {
+            let claim_assertion = store.get_claim_assertion_from_uri(
+                &jumbf::labels::to_absolute_uri(claim.label(), &assertion.url()),
+            )?;
             let assertion = claim_assertion.assertion();
             let label = claim_assertion.label();
             let base_label = assertion.label();
@@ -1659,8 +1662,8 @@ pub(crate) mod tests {
             .expect("embed");
 
         //let manifest_store = crate::ManifestStore::from_file(&sidecar).expect("from_file");
-        let manifest_store =
-            crate::ManifestStore::from_bytes("c2pa", &c2pa_data, true).expect("from_bytes");
+        let manifest_store = crate::ManifestStore::from_bytes("application/c2pa", &c2pa_data, true)
+            .expect("from_bytes");
         assert_eq!(manifest_store.active_label(), Some("MyLabel"));
         assert_eq!(
             manifest_store.get_active().unwrap().title().unwrap(),

--- a/sdk/src/manifest_store.rs
+++ b/sdk/src/manifest_store.rs
@@ -82,10 +82,7 @@ impl ManifestStore {
     }
 
     /// creates a ManifestStore from a Store with validation
-    pub(crate) fn from_store(
-        store: &Store,
-        validation_log: &mut impl StatusTracker,
-    ) -> ManifestStore {
+    pub(crate) fn from_store(store: &Store, validation_log: &impl StatusTracker) -> ManifestStore {
         Self::from_store_impl(
             store,
             validation_log,
@@ -98,7 +95,7 @@ impl ManifestStore {
     #[cfg(feature = "file_io")]
     pub fn from_store_with_resources(
         store: &Store,
-        validation_log: &mut impl StatusTracker,
+        validation_log: &impl StatusTracker,
         resource_path: &Path,
     ) -> ManifestStore {
         Self::from_store_impl(store, validation_log, Some(resource_path))
@@ -107,7 +104,7 @@ impl ManifestStore {
     // internal implementation of from_store
     fn from_store_impl(
         store: &Store,
-        validation_log: &mut impl StatusTracker,
+        validation_log: &impl StatusTracker,
         #[cfg(feature = "file_io")] resource_path: Option<&Path>,
     ) -> ManifestStore {
         let mut statuses = status_for_store(store, validation_log);
@@ -146,7 +143,7 @@ impl ManifestStore {
         let store = manifest.to_store()?;
         Ok(Self::from_store_impl(
             &store,
-            &mut OneShotStatusTracker::new(),
+            &OneShotStatusTracker::new(),
             #[cfg(feature = "file_io")]
             manifest.resources().base_path(),
         ))
@@ -157,7 +154,7 @@ impl ManifestStore {
         let mut validation_log = DetailedStatusTracker::new();
 
         Store::load_from_memory(format, image_bytes, verify, &mut validation_log)
-            .map(|store| Self::from_store(&store, &mut validation_log))
+            .map(|store| Self::from_store(&store, &validation_log))
     }
 
     #[cfg(feature = "file_io")]
@@ -177,7 +174,7 @@ impl ManifestStore {
         let mut validation_log = DetailedStatusTracker::new();
 
         let store = Store::load_from_asset(path.as_ref(), true, &mut validation_log)?;
-        Ok(Self::from_store(&store, &mut validation_log))
+        Ok(Self::from_store(&store, &validation_log))
     }
 
     #[cfg(feature = "file_io")]
@@ -205,7 +202,7 @@ impl ManifestStore {
         let store = Store::load_from_asset(path.as_ref(), true, &mut validation_log)?;
         Ok(Self::from_store_with_resources(
             &store,
-            &mut validation_log,
+            &validation_log,
             resource_path.as_ref(),
         ))
     }
@@ -220,7 +217,7 @@ impl ManifestStore {
 
         Store::load_from_memory_async(format, image_bytes, verify, &mut validation_log)
             .await
-            .map(|store| Self::from_store(&store, &mut validation_log))
+            .map(|store| Self::from_store(&store, &validation_log))
     }
 
     /// Loads a ManifestStore from an init segment and fragment.  This
@@ -242,7 +239,7 @@ impl ManifestStore {
             &mut validation_log,
         )
         .await
-        .map(|store| Self::from_store(&store, &mut validation_log))
+        .map(|store| Self::from_store(&store, &validation_log))
     }
 
     /// Asynchronously loads a manifest from a buffer holding a binary manifest (.c2pa) and validates against an asset buffer
@@ -281,7 +278,7 @@ impl ManifestStore {
         )
         .await?;
 
-        Ok(Self::from_store(&store, &mut validation_log))
+        Ok(Self::from_store(&store, &validation_log))
     }
 
     /// Synchronously loads a manifest from a buffer holding a binary manifest (.c2pa) and validates against an asset buffer
@@ -318,7 +315,7 @@ impl ManifestStore {
             &mut validation_log,
         )?;
 
-        Ok(Self::from_store(&store, &mut validation_log))
+        Ok(Self::from_store(&store, &validation_log))
     }
 }
 
@@ -397,7 +394,7 @@ mod tests {
     fn manifest_report() {
         let store = create_test_store().expect("creating test store");
 
-        let manifest_store = ManifestStore::from_store(&store, &mut OneShotStatusTracker::new());
+        let manifest_store = ManifestStore::from_store(&store, &OneShotStatusTracker::new());
         assert!(manifest_store.active_manifest.is_some());
         assert!(!manifest_store.manifests.is_empty());
         let manifest = manifest_store.get_active().unwrap();

--- a/sdk/src/manifest_store.rs
+++ b/sdk/src/manifest_store.rs
@@ -25,7 +25,7 @@ use crate::{
     store::Store,
     utils::base64,
     validation_status::{status_for_store, ValidationStatus},
-    Manifest, Result,
+    CAIRead, Manifest, Result,
 };
 
 #[derive(Serialize)]
@@ -44,7 +44,7 @@ pub struct ManifestStore {
 
 impl ManifestStore {
     /// allocates a new empty ManifestStore
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         ManifestStore {
             active_manifest: None,
             manifests: HashMap::<String, Manifest>::new(),
@@ -149,12 +149,33 @@ impl ManifestStore {
         ))
     }
 
-    /// generate a Store from a format string and bytes
+    /// Generate a Store from a format string and bytes.
     pub fn from_bytes(format: &str, image_bytes: &[u8], verify: bool) -> Result<ManifestStore> {
         let mut validation_log = DetailedStatusTracker::new();
 
         Store::load_from_memory(format, image_bytes, verify, &mut validation_log)
             .map(|store| Self::from_store(&store, &validation_log))
+    }
+
+    /// Generate a Store from a format string and stream.
+    pub fn from_stream(
+        format: &str,
+        stream: &mut dyn CAIRead,
+        verify: bool,
+    ) -> Result<ManifestStore> {
+        let mut validation_log = DetailedStatusTracker::new();
+
+        let manifest_bytes = Store::load_jumbf_from_stream(format, stream)?;
+        let store = Store::from_jumbf(&manifest_bytes, &mut validation_log)?;
+        if verify {
+            // verify store and claims
+            Store::verify_store(
+                &store,
+                &mut ClaimAssetData::Stream(stream, format),
+                &mut validation_log,
+            )?;
+        }
+        Ok(Self::from_store(&store, &validation_log))
     }
 
     #[cfg(feature = "file_io")]
@@ -487,6 +508,23 @@ mod tests {
             "../target/ms",
         )
         .expect("from_store_with_resources");
+        println!("{manifest_store}");
+
+        assert!(manifest_store.active_label().is_some());
+        assert!(manifest_store.get_active().is_some());
+        assert!(!manifest_store.manifests().is_empty());
+        assert!(manifest_store.validation_status().is_none());
+        let manifest = manifest_store.get_active().unwrap();
+        assert!(!manifest.ingredients().is_empty());
+        assert_eq!(manifest.issuer().unwrap(), "C2PA Test Signing Cert");
+        assert!(manifest.time().is_some());
+    }
+
+    #[test]
+    fn manifest_report_from_stream() {
+        let image_bytes: &[u8] = include_bytes!("../tests/fixtures/CA.jpg");
+        let mut stream = std::io::Cursor::new(image_bytes);
+        let manifest_store = ManifestStore::from_stream("image/jpeg", &mut stream, true).unwrap();
         println!("{manifest_store}");
 
         assert!(manifest_store.active_label().is_some());

--- a/sdk/src/manifest_store_report.rs
+++ b/sdk/src/manifest_store_report.rs
@@ -124,7 +124,7 @@ impl ManifestStoreReport {
     /// Creates a ManifestStoreReport from an existing Store and a validation log
     pub(crate) fn from_store_with_log(
         store: &Store,
-        validation_log: &mut impl StatusTracker,
+        validation_log: &impl StatusTracker,
     ) -> Result<Self> {
         let mut report = Self::from_store(store)?;
 
@@ -149,7 +149,7 @@ impl ManifestStoreReport {
     pub fn from_bytes(format: &str, image_bytes: &[u8]) -> Result<Self> {
         let mut validation_log = DetailedStatusTracker::new();
         let store = Store::load_from_memory(format, image_bytes, true, &mut validation_log)?;
-        Self::from_store_with_log(&store, &mut validation_log)
+        Self::from_store_with_log(&store, &validation_log)
     }
 
     /// Creates a ManifestStoreReport from a file
@@ -157,7 +157,7 @@ impl ManifestStoreReport {
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         let mut validation_log = DetailedStatusTracker::new();
         let store = Store::load_from_asset(path.as_ref(), true, &mut validation_log)?;
-        Self::from_store_with_log(&store, &mut validation_log)
+        Self::from_store_with_log(&store, &validation_log)
     }
 
     /// create a json string representation of this structure, omitting binaries

--- a/sdk/src/resource_store.rs
+++ b/sdk/src/resource_store.rs
@@ -58,14 +58,14 @@ impl UriOrResource {
         &self,
         resources: &mut ResourceStore,
         claim: &Claim,
-        id: &str,
     ) -> Result<UriOrResource> {
         match self {
             UriOrResource::ResourceRef(r) => Ok(UriOrResource::ResourceRef(r.clone())),
             UriOrResource::HashedUri(h) => {
-                let data_box = claim.find_databox(&h.url()).ok_or(Error::MissingDataBox)?;
+                let uri = crate::jumbf::labels::to_absolute_uri(claim.label(), &h.url());
+                let data_box = claim.find_databox(&uri).ok_or(Error::MissingDataBox)?;
                 let resource_ref =
-                    resources.add_with(id, &data_box.format, data_box.data.clone())?;
+                    resources.add_with(&h.url(), &data_box.format, data_box.data.clone())?;
                 Ok(UriOrResource::ResourceRef(resource_ref))
             }
         }
@@ -235,6 +235,12 @@ impl ResourceStore {
                     id = format!("{}/{id}", label);
                 }
                 id = id.replace([':'], "_");
+                // add a file extension if it doesn't have one
+                if !(id.ends_with(".jpeg") || id.ends_with(".png")) {
+                    if let Some(ext) = crate::utils::mime::format_to_extension(format) {
+                        id = format!("{}.{}", id, ext);
+                    }
+                }
             }
             if !self.exists(&id) {
                 self.add(&id, value)?;

--- a/sdk/src/resource_store.rs
+++ b/sdk/src/resource_store.rs
@@ -11,9 +11,12 @@
 // specific language governing permissions and limitations under
 // each license.
 
-#[cfg(feature = "file_io")]
-use std::path::{Path, PathBuf};
 use std::{borrow::Cow, collections::HashMap};
+#[cfg(feature = "file_io")]
+use std::{
+    fs::{create_dir_all, read, write},
+    path::{Path, PathBuf},
+};
 
 #[cfg(feature = "json_schema")]
 use schemars::JsonSchema;
@@ -110,6 +113,8 @@ pub struct ResourceStore {
     #[cfg(feature = "file_io")]
     #[serde(skip_serializing_if = "Option::is_none")]
     base_path: Option<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    label: Option<String>,
 }
 
 impl ResourceStore {
@@ -118,7 +123,13 @@ impl ResourceStore {
             resources: HashMap::new(),
             #[cfg(feature = "file_io")]
             base_path: None,
+            label: None,
         }
+    }
+
+    pub fn set_label<S: Into<String>>(&mut self, label: S) -> &Self {
+        self.label = Some(label.into());
+        self
     }
 
     #[cfg(feature = "file_io")]
@@ -142,7 +153,7 @@ impl ResourceStore {
             "jpg" | "jpeg" | "image/jpeg" => ".jpg",
             "png" | "image/png" => ".png",
             //make "svg" | "image/svg+xml" => ".svg",
-            "c2pa" | "application/x-c2pa-manifest-store" => ".cp2a",
+            "c2pa" | "application/x-c2pa-manifest-store" => ".c2pa",
             _ => "",
         };
         // clean string for possible filesystem use
@@ -170,6 +181,43 @@ impl ResourceStore {
         Ok(ResourceRef::new(format, id))
     }
 
+    /// Adds a resource from a URI, generating a [`ResourceRef`].
+    ///
+    /// The generated identifier may be different from the key.
+    pub(crate) fn add_uri<R>(
+        &mut self,
+        uri: &str,
+        format: &str,
+        value: R,
+    ) -> crate::Result<ResourceRef>
+    where
+        R: Into<Vec<u8>>,
+    {
+        #[cfg(feature = "file_io")]
+        let mut id = uri.to_string();
+        #[cfg(not(feature = "file_io"))]
+        let id = uri.to_string();
+
+        // if it isn't jumbf, assume it's an external uri and use it as is
+        if id.starts_with("self#jumbf=") {
+            #[cfg(feature = "file_io")]
+            if self.base_path.is_some() {
+                // convert to a file path always including the manifest label
+                id = id.replace("self#jumbf=", "");
+                if id.starts_with("/c2pa/") {
+                    id = id.replacen("/c2pa/", "", 1);
+                } else if let Some(label) = self.label.as_ref() {
+                    id = format!("{}/{id}", label);
+                }
+                id = id.replace([':'], "_");
+            }
+            if !self.exists(&id) {
+                self.add(&id, value)?;
+            }
+        }
+        Ok(ResourceRef::new(format, id))
+    }
+
     /// Adds a resource, using a given id value.
     pub fn add<S, R>(&mut self, id: S, value: R) -> crate::Result<&mut Self>
     where
@@ -179,9 +227,8 @@ impl ResourceStore {
         #[cfg(feature = "file_io")]
         if let Some(base) = self.base_path.as_ref() {
             let path = base.join(id.into());
-            std::fs::create_dir_all(path.parent().unwrap_or(Path::new("")))?;
-            #[allow(clippy::expect_used)]
-            std::fs::write(path, value.into())?;
+            create_dir_all(path.parent().unwrap_or(Path::new("")))?;
+            write(path, value.into())?;
             return Ok(self);
         }
         self.resources.insert(id.into(), value.into());
@@ -202,7 +249,7 @@ impl ResourceStore {
                 Some(base) => {
                     // read the file, save in Map and then return a reference
                     let path = base.join(id);
-                    let value = std::fs::read(path).map_err(|_| {
+                    let value = read(path).map_err(|_| {
                         let path = base.join(id).to_string_lossy().into_owned();
                         Error::ResourceNotFound(path)
                     })?;

--- a/sdk/src/resource_store.rs
+++ b/sdk/src/resource_store.rs
@@ -303,13 +303,11 @@ mod tests {
         println!("{manifest}");
 
         let image = include_bytes!("../tests/fixtures/earth_apollo17.jpg");
-        // convert buffer to cursor with Read/Write/Seek capability
-        let mut stream = std::io::Cursor::new(image.to_vec());
 
         let signer = temp_signer();
         // Embed a manifest using the signer.
         let output_image = manifest
-            .embed_stream("jpeg", &mut stream, signer.as_ref())
+            .embed_from_memory("jpeg", image, signer.as_ref())
             .expect("embed_stream");
 
         let _manifest_store =

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -39,7 +39,7 @@ use crate::{
     jumbf::{
         self,
         boxes::*,
-        labels::{ASSERTIONS, CREDENTIALS, DATABOXES, SIGNATURE},
+        labels::{to_absolute_uri, ASSERTIONS, CREDENTIALS, DATABOXES, SIGNATURE},
     },
     jumbf_io::{
         get_assetio_handler, load_jumbf_from_stream, object_locations_from_stream,
@@ -352,6 +352,11 @@ impl Store {
             None => self.get_claim(target_claim_label), //  relative so use the target claim label
         }
         .and_then(|claim| {
+            let uri = if target_claim_label != self.label() {
+                to_absolute_uri(target_claim_label, uri)
+            } else {
+                uri.to_owned()
+            };
             claim
                 .databoxes()
                 .iter()

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -1627,13 +1627,13 @@ impl Store {
 
     /// This function is used to pre-generate a manifest with place holders for the final
     /// DataHash and Manifest Signature.  The DataHash will reserve space for at least 10
-    /// Exclusion ranges.  The Signature box reserved size is based on the size returned by
-    /// the Signer.  This function is not needed when using Box Hash. This function is used
+    /// Exclusion ranges.  The Signature box reserved size is based on the size required by
+    /// the Signer you plan to use.  This function is not needed when using Box Hash. This function is used
     /// in conjunction with `get_data_hashed_embeddable_manifest`.  The manifest returned
     /// from `get_data_hashed_embeddable_manifest` will have a size that matches this function.
     pub fn get_data_hashed_manifest_placeholder(
         &mut self,
-        signer: &dyn Signer,
+        reserve_size: usize,
         format: &str,
     ) -> Result<Vec<u8>> {
         let pc = self.provenance_claim_mut().ok_or(Error::ClaimEncoding)?;
@@ -1652,7 +1652,7 @@ impl Store {
             pc.add_assertion_with_salt(&ph, &DefaultSalt::default())?;
         }
 
-        let jumbf_bytes = self.to_jumbf_internal(signer.reserve_size())?;
+        let jumbf_bytes = self.to_jumbf_internal(reserve_size)?;
 
         let composed = self.get_composed_manifest(&jumbf_bytes, format)?;
 
@@ -1724,6 +1724,73 @@ impl Store {
         self.get_composed_manifest(&jumbf_bytes, format)
     }
 
+    /// Returns a finalized, signed manifest.  The manfiest are only supported
+    /// for cases when the client has provided a data hash content hash binding.  Note,
+    /// this function will not work for cases like BMFF where the position
+    /// of the content is also encoded.  This function is not compatible with
+    /// BMFF hash binding.  If a BMFF data hash or box hash is detected that is
+    /// an error.  The DataHash placeholder assertion will be  adjusted to the contain
+    /// the correct values.  If the asset_reader value is supplied it will also perform
+    /// the hash calulations, otherwise the function uses the caller supplied values.  
+    /// It is an error if `get_data_hashed_manifest_placeholder` was not called first
+    /// as this call inserts the DataHash placeholder assertion to reserve space for the
+    /// actual hash values not required when using BoxHashes.  
+    pub async fn get_data_hashed_embeddable_manifest_async(
+        &mut self,
+        dh: &DataHash,
+        signer: &dyn AsyncSigner,
+        format: &str,
+        asset_reader: Option<&mut dyn CAIRead>,
+    ) -> Result<Vec<u8>> {
+        let pc = self.provenance_claim_mut().ok_or(Error::ClaimEncoding)?;
+
+        // make sure there are data hashes present before generating
+        if pc.hash_assertions().is_empty() {
+            return Err(Error::BadParam(
+                "Claim must have hash binding assertion".to_string(),
+            ));
+        }
+
+        // don't allow BMFF assertions to be present
+        if !pc.bmff_hash_assertions().is_empty() {
+            return Err(Error::BadParam(
+                "BMFF assertions not supported in embeddable manifests".to_string(),
+            ));
+        }
+
+        let mut adusted_dh = DataHash::new("jumbf manifest", pc.alg());
+        adusted_dh.exclusions = dh.exclusions.clone();
+        adusted_dh.hash = dh.hash.clone();
+
+        if let Some(reader) = asset_reader {
+            // calc hashes
+            adusted_dh.gen_hash_from_stream(reader)?;
+        }
+
+        // update the placeholder hash
+        pc.update_data_hash(adusted_dh)?;
+
+        // reborrow immuttable
+        let pc = self.provenance_claim().ok_or(Error::ClaimEncoding)?;
+        let mut jumbf_bytes = self.to_jumbf_internal(signer.reserve_size())?;
+
+        // sign contents
+        let sig = self
+            .sign_claim_async(pc, signer, signer.reserve_size())
+            .await?;
+
+        let sig_placeholder = Store::sign_claim_placeholder(pc, signer.reserve_size());
+
+        if sig_placeholder.len() != sig.len() {
+            return Err(Error::CoseSigboxTooSmall);
+        }
+
+        patch_bytes(&mut jumbf_bytes, &sig_placeholder, &sig)
+            .map_err(|_| Error::JumbfCreationError)?;
+
+        self.get_composed_manifest(&jumbf_bytes, format)
+    }
+
     /// Returns a finalized, signed manifest.  The client is required to have
     /// included the necessary box hash assertion with the pregenerated hashes.
     pub fn get_box_hashed_embeddable_manifest(&mut self, signer: &dyn Signer) -> Result<Vec<u8>> {
@@ -1745,6 +1812,44 @@ impl Store {
 
         // sign contents
         let sig = self.sign_claim(pc, signer, signer.reserve_size())?;
+        let sig_placeholder = Store::sign_claim_placeholder(pc, signer.reserve_size());
+
+        if sig_placeholder.len() != sig.len() {
+            return Err(Error::CoseSigboxTooSmall);
+        }
+
+        patch_bytes(&mut jumbf_bytes, &sig_placeholder, &sig)
+            .map_err(|_| Error::JumbfCreationError)?;
+
+        Ok(jumbf_bytes)
+    }
+
+    /// Returns a finalized, signed manifest.  The client is required to have
+    /// included the necessary box hash assertion with the pregenerated hashes.
+    pub async fn get_box_hashed_embeddable_manifest_async(
+        &mut self,
+        signer: &dyn AsyncSigner,
+    ) -> Result<Vec<u8>> {
+        let pc = self.provenance_claim().ok_or(Error::ClaimEncoding)?;
+
+        // make sure there is only one
+        if pc.hash_assertions().len() != 1 {
+            return Err(Error::BadParam(
+                "Claim must have exactly one hash binding assertion".to_string(),
+            ));
+        }
+
+        // only allow box hash assertions to be present
+        if pc.box_hash_assertions().is_empty() {
+            return Err(Error::BadParam("Missing box hash assertion".to_string()));
+        }
+
+        let mut jumbf_bytes = self.to_jumbf_internal(signer.reserve_size())?;
+
+        // sign contents
+        let sig = self
+            .sign_claim_async(pc, signer, signer.reserve_size())
+            .await?;
         let sig_placeholder = Store::sign_claim_placeholder(pc, signer.reserve_size());
 
         if sig_placeholder.len() != sig.len() {
@@ -4454,6 +4559,88 @@ pub mod tests {
             }
         }
     }
+
+    #[actix::test]
+    #[cfg(feature = "file_io")]
+    async fn test_boxhash_embeddable_manifest_async() {
+        // test adding to actual image
+        let ap = fixture_path("boxhash.jpg");
+        let box_hash_path = fixture_path("boxhash.json");
+
+        // Create claims store.
+        let mut store = Store::new();
+
+        // Create a new claim.
+        let mut claim = create_test_claim().unwrap();
+
+        // add box hash for CA.jpg
+        let box_hash_data = std::fs::read(box_hash_path).unwrap();
+        let assertion = Assertion::from_data_json(BOX_HASH, &box_hash_data).unwrap();
+        let box_hash = BoxHash::from_json_assertion(&assertion).unwrap();
+        claim.add_assertion(&box_hash).unwrap();
+
+        store.commit_claim(claim).unwrap();
+
+        // Do we generate JUMBF?
+        let signer = crate::openssl::temp_signer_async::AsyncSignerAdapter::new(SigningAlg::Ps256);
+
+        // get the embeddable manifest
+        let em = store
+            .get_box_hashed_embeddable_manifest_async(&signer)
+            .await
+            .unwrap();
+
+        // get composed version for embedding to JPEG
+        let cm = store.get_composed_manifest(&em, "jpg").unwrap();
+
+        // insert manifest into ouput asset
+        let jpeg_io = get_assetio_handler_from_path(&ap).unwrap();
+        let ol = jpeg_io.get_object_locations(&ap).unwrap();
+
+        let cai_loc = ol
+            .iter()
+            .find(|o| o.htype == HashBlockObjectType::Cai)
+            .unwrap();
+
+        // remove any existing manifest
+        jpeg_io.read_cai_store(&ap).unwrap();
+
+        // build new asset in memory inserting new manifest
+        let outbuf = Vec::new();
+        let mut out_stream = Cursor::new(outbuf);
+        let mut input_file = std::fs::File::open(&ap).unwrap();
+
+        // write before
+        let mut before = vec![0u8; cai_loc.offset];
+        input_file.read_exact(before.as_mut_slice()).unwrap();
+        out_stream.write_all(&before).unwrap();
+
+        // write composed bytes
+        out_stream.write_all(&cm).unwrap();
+
+        // write bytes after
+        let mut after_buf = Vec::new();
+        input_file.read_to_end(&mut after_buf).unwrap();
+        out_stream.write_all(&after_buf).unwrap();
+
+        // save to output file
+        let temp_dir = tempfile::tempdir().unwrap();
+        let output = temp_dir_path(&temp_dir, "boxhash-out.jpg");
+        let mut output_file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&output)
+            .unwrap();
+        output_file.write_all(&out_stream.into_inner()).unwrap();
+
+        let mut report = DetailedStatusTracker::new();
+        let _new_store = Store::load_from_asset(&output, true, &mut report).unwrap();
+
+        let errors = report_split_errors(report.get_log_mut());
+        assert!(errors.is_empty());
+    }
+
     #[test]
     #[cfg(feature = "file_io")]
     fn test_boxhash_embeddable_manifest() {
@@ -4534,6 +4721,68 @@ pub mod tests {
         assert!(errors.is_empty());
     }
 
+    #[actix::test]
+    #[cfg(feature = "file_io")]
+    async fn test_datahash_embeddable_manifest_async() {
+        // test adding to actual image
+        let ap = fixture_path("cloud.jpg");
+
+        // Do we generate JUMBF?
+        let signer = crate::openssl::temp_signer_async::AsyncSignerAdapter::new(SigningAlg::Ps256);
+
+        // Create claims store.
+        let mut store = Store::new();
+
+        // Create a new claim.
+        let claim = create_test_claim().unwrap();
+
+        store.commit_claim(claim).unwrap();
+
+        // get a placeholder the manifest
+        let placeholder = store
+            .get_data_hashed_manifest_placeholder(signer.reserve_size(), "jpeg")
+            .unwrap();
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let output = temp_dir_path(&temp_dir, "boxhash-out.jpg");
+        let mut output_file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&output)
+            .unwrap();
+
+        // write a jpeg file with a placeholder for the manifest (returns offset of the placeholder)
+        let offset =
+            write_jpeg_placeholder_file(&placeholder, &ap, &mut output_file, None).unwrap();
+
+        // build manifest to insert in the hole
+
+        // create an hash exclusion for the manifest
+        let exclusion = HashRange::new(offset, placeholder.len());
+        let exclusions = vec![exclusion];
+
+        let mut dh = DataHash::new("source_hash", "sha256");
+        dh.exclusions = Some(exclusions);
+
+        // get the embeddable manifest, letting API do the hashing
+        output_file.rewind().unwrap();
+        let cm = store
+            .get_data_hashed_embeddable_manifest_async(&dh, &signer, "jpeg", Some(&mut output_file))
+            .await
+            .unwrap();
+
+        // path in new composed manifest
+        output_file.seek(SeekFrom::Start(offset as u64)).unwrap();
+        output_file.write_all(&cm).unwrap();
+
+        let mut report = DetailedStatusTracker::new();
+        let _new_store = Store::load_from_asset(&output, true, &mut report).unwrap();
+
+        let errors = report_split_errors(report.get_log_mut());
+        assert!(errors.is_empty());
+    }
+
     #[test]
     #[cfg(feature = "file_io")]
     fn test_datahash_embeddable_manifest() {
@@ -4553,7 +4802,7 @@ pub mod tests {
 
         // get a placeholder the manifest
         let placeholder = store
-            .get_data_hashed_manifest_placeholder(signer.as_ref(), "jpeg")
+            .get_data_hashed_manifest_placeholder(signer.reserve_size(), "jpeg")
             .unwrap();
 
         let temp_dir = tempfile::tempdir().unwrap();
@@ -4621,7 +4870,7 @@ pub mod tests {
 
         // get a placeholder for the manifest
         let placeholder = store
-            .get_data_hashed_manifest_placeholder(signer.as_ref(), "jpeg")
+            .get_data_hashed_manifest_placeholder(signer.reserve_size(), "jpeg")
             .unwrap();
 
         let temp_dir = tempfile::tempdir().unwrap();

--- a/sdk/src/store.rs
+++ b/sdk/src/store.rs
@@ -156,7 +156,7 @@ impl Store {
         if let Some(bh) = self.manifest_box_hash_cache.get(claim.label()) {
             bh.clone()
         } else {
-            Store::calc_manifest_box_hash(claim, None, claim.alg()).unwrap_or(Vec::new())
+            Store::calc_manifest_box_hash(claim, None, claim.alg()).unwrap_or_default()
         }
     }
 

--- a/sdk/src/time_stamp.rs
+++ b/sdk/src/time_stamp.rs
@@ -236,7 +236,7 @@ impl TimeStampResponse {
                     token
                         .content
                         .clone()
-                        .decode(|cons| SignedData::take_from(cons))
+                        .decode(SignedData::take_from)
                         .map_err(|_err| Error::CoseTimeStampGeneration)?,
                 ))
             } else {

--- a/sdk/src/utils/hash_utils.rs
+++ b/sdk/src/utils/hash_utils.rs
@@ -139,14 +139,14 @@ impl Hasher {
 pub fn hash_by_alg(alg: &str, data: &[u8], exclusions: Option<Vec<HashRange>>) -> Vec<u8> {
     let mut reader = Cursor::new(data);
 
-    hash_stream_by_alg(alg, &mut reader, exclusions, true).unwrap_or(Vec::new())
+    hash_stream_by_alg(alg, &mut reader, exclusions, true).unwrap_or_default()
 }
 
 // Return hash inclusive bytes for desired hashing algorithm.
 pub fn hash_by_alg_with_inclusions(alg: &str, data: &[u8], inclusions: Vec<HashRange>) -> Vec<u8> {
     let mut reader = Cursor::new(data);
 
-    hash_stream_by_alg(alg, &mut reader, Some(inclusions), false).unwrap_or(Vec::new())
+    hash_stream_by_alg(alg, &mut reader, Some(inclusions), false).unwrap_or_default()
 }
 
 // Return hash bytes for asset using desired hashing algorithm.

--- a/sdk/src/utils/mime.rs
+++ b/sdk/src/utils/mime.rs
@@ -1,0 +1,74 @@
+// Copyright 2022 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License,
+// Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+// or the MIT license (http://opensource.org/licenses/MIT),
+// at your option.
+
+// Unless required by applicable law or agreed to in writing,
+// this software is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or
+// implied. See the LICENSE-MIT and LICENSE-APACHE files for the
+// specific language governing permissions and limitations under
+// each license.
+
+/// Converts a file extension to a MIME type
+pub fn extension_to_mime(extension: &str) -> Option<&'static str> {
+    Some(match extension {
+        "jpg" | "jpeg" => "image/jpeg",
+        "png" => "image/png",
+        "gif" => "image/gif",
+        "psd" => "image/vnd.adobe.photoshop",
+        "tiff" => "image/tiff",
+        "svg" => "image/svg+xml",
+        "ico" => "image/x-icon",
+        "bmp" => "image/bmp",
+        "webp" => "image/webp",
+        "dng" => "image/dng",
+        "heic" => "image/heic",
+        "heif" => "image/heif",
+        "mp2" | "mpa" | "mpe" | "mpeg" | "mpg" | "mpv2" => "video/mpeg",
+        "mp4" => "video/mp4",
+        "avif" => "image/avif",
+        "mov" | "qt" => "video/quicktime",
+        "m4a" => "audio/mp4",
+        "mid" | "rmi" => "audio/mid",
+        "mp3" => "audio/mpeg",
+        "wav" => "audio/vnd.wav",
+        "aif" | "aifc" | "aiff" => "audio/aiff",
+        "ogg" => "audio/ogg",
+        "pdf" => "application/pdf",
+        "ai" => "application/postscript",
+        _ => return None,
+    })
+}
+
+/// Converts a format to a file extension
+pub fn format_to_extension(format: &str) -> Option<&'static str> {
+    Some(match format {
+        "jpg" | "jpeg" | "image/jpeg" => "jpg",
+        "png" | "image/png" => "png",
+        "gif" | "image/gif" => "gif",
+        "psd" | "image/vnd.adobe.photoshop" => "psd",
+        "tiff" | "image/tiff" => "tiff",
+        "svg" | "image/svg+xml" => "svg",
+        "ico" | "image/x-icon" => "ico",
+        "bmp" | "image/bmp" => "bmp",
+        "webp" | "image/webp" => "webp",
+        "dng" | "image/dng" => "dng",
+        "heic" | "image/heic" => "heic",
+        "heif" | "image/heif" => "heif",
+        "mp2" | "mpa" | "mpe" | "mpeg" | "mpg" | "mpv2" | "video/mpeg" => "mp2",
+        "mp4" | "video/mp4" => "mp4",
+        "avif" | "image/avif" => "avif",
+        "mov" | "qt" | "video/quicktime" => "mov",
+        "m4a" | "audio/mp4" => "m4a",
+        "mid" | "rmi" | "audio/mid" => "mid",
+        "mp3" | "audio/mpeg" => "mp3",
+        "wav" | "audio/vnd.wav" => "wav",
+        "aif" | "aifc" | "aiff" | "audio/aiff" => "aif",
+        "ogg" | "audio/ogg" => "ogg",
+        "pdf" | "application/pdf" => "pdf",
+        "ai" | "application/postscript" => "ai",
+        _ => return None,
+    })
+}

--- a/sdk/src/utils/mod.rs
+++ b/sdk/src/utils/mod.rs
@@ -16,6 +16,8 @@ pub(crate) mod cbor_types;
 #[allow(dead_code)]
 pub(crate) mod hash_utils;
 pub(crate) mod merkle;
+#[cfg(feature = "file_io")]
+pub(crate) mod mime;
 #[allow(dead_code)] // for wasm build
 pub(crate) mod patch;
 #[cfg(feature = "add_thumbnails")]

--- a/sdk/src/validation_status.rs
+++ b/sdk/src/validation_status.rs
@@ -161,7 +161,7 @@ impl PartialEq for ValidationStatus {
 /// be reported as a validation error for any ingredient.
 pub fn status_for_store(
     store: &Store,
-    validation_log: &mut impl StatusTracker,
+    validation_log: &impl StatusTracker,
 ) -> Vec<ValidationStatus> {
     let statuses: Vec<ValidationStatus> = validation_log
         .get_log()


### PR DESCRIPTION
## Changes in this pull request

Integrate upstream changes prior to commencing work on C2PA-272.

Required for corresponding PRs [#11 to Monotype/c2patool](https://github.com/Monotype/c2patool/pull/11) and [#4 to Monotype/c2pa-js](https://github.com/Monotype/c2pa-js/pull/4).

Depends on a [corresponding PR for Monotype/rust-font-tools](https://github.com/Monotype/rust-font-tools/pull/3).

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
