### PR TITLE
C2PA-305: Use of a `enum FontError` in the `font_io` handler.

### DIFF
--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -19,7 +19,57 @@ use byteorder::{BigEndian, ByteOrder, ReadBytesExt, WriteBytesExt};
 
 use crate::error::{Error, Result};
 
-/// Types for supporting fonts in any container.
+// Types for supporting fonts in any container.
+
+/// Errors that can occur when working with fonts.
+#[derive(Debug, thiserror::Error)]
+pub enum FontError {
+    /// Failed to parse or de-serialize font data
+    #[error("Failed to de-serialize data")]
+    DeserializationError,
+
+    /// Failed to load a font.
+    #[error("Failed to load font")]
+    FontLoadError,
+
+    /// Failed to load the font's 'C2PA' table, either because it was missing or
+    /// because it was truncated/bad.
+    #[error("C2PA table bad or missing")]
+    FontLoadC2PATableBadMissing,
+
+    /// The font's 'C2PA' table contains invalid UTF-8 data.
+    #[error("C2PA table manifest data is not valid UTF-8")]
+    FontLoadC2PATableInvalidUtf8,
+
+    /// The font's 'C2PA' table is truncated.
+    #[error("C2PA table claimed sizes exceed actual")]
+    FontLoadC2PATableTruncated,
+
+    /// The font's 'head' table is bad or missing.
+    #[error("head table bad or missing")]
+    FontLoadHeadTableBadMissing,
+
+    /// The font's SFNT header is bad or missing.
+    #[error("SFNT header bad or missing")]
+    FontLoadSfntHeaderBadMissing,
+
+    /// Failed to save the font.
+    #[error("Failed to save font")]
+    FontSaveError,
+
+    /// The font is missing a valid 'magic' number, therefore an unknown font type.
+    #[error("Unknown font format, the 'magic' number is not recognized.")]
+    UnknownMagic,
+
+    /// Invalid font format
+    #[error("Failed to load font")]
+    UnsupportedFontError,
+}
+
+/// Helper method for wrapping a FontError into a crate level error.
+pub(crate) fn wrap_font_err(e: FontError) -> Error {
+    Error::FontError(e)
+}
 
 /// Four-character tag which names a font table.
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -117,7 +167,7 @@ pub(crate) const SFNT_EXPECTED_CHECKSUM: u32 = 0xb1b0afba;
 
 /// Used to attempt conversion from u32 to a Magic value.
 impl TryFrom<u32> for Magic {
-    type Error = crate::error::Error;
+    type Error = FontError;
 
     /// Try to match the given u32 value to a known font-format magic number.
     fn try_from(v: u32) -> core::result::Result<Self, Self::Error> {
@@ -128,7 +178,7 @@ impl TryFrom<u32> for Magic {
             at if at == Magic::AppleTrue as u32 => Ok(Magic::AppleTrue),
             w1 if w1 == Magic::Woff as u32 => Ok(Magic::Woff),
             w2 if w2 == Magic::Woff2 as u32 => Ok(Magic::Woff2),
-            _unknown => Err(Error::FontUnknownMagic),
+            _unknown => Err(FontError::UnknownMagic),
         }
     }
 }
@@ -139,6 +189,9 @@ impl TryFrom<u32> for Magic {
 /// # Remarks
 /// Note that trailing pad bytes do not affect this checksum - it's not a real
 /// CRC.
+///
+/// # Panics
+/// Panics if the the `bytes` array is not aligned on a 4-byte boundary.
 #[allow(dead_code)]
 pub(crate) fn checksum(bytes: &[u8]) -> Wrapping<u32> {
     // Cut your pie into 1x4cm pieces to serve
@@ -378,9 +431,9 @@ impl TableC2PA {
         reader: &mut T,
         offset: u64,
         size: usize,
-    ) -> core::result::Result<TableC2PA, Error> {
+    ) -> Result<TableC2PA> {
         if size < size_of::<TableC2PARaw>() {
-            Err(Error::FontLoadC2PATableTruncated)
+            Err(wrap_font_err(FontError::FontLoadC2PATableTruncated))
         } else {
             let mut active_manifest_uri: Option<String> = None;
             let mut manifest_store: Option<Vec<u8>> = None;
@@ -393,7 +446,7 @@ impl TableC2PA {
                     + raw_table.activeManifestUriLength as usize
                     + raw_table.manifestStoreLength as usize
             {
-                return Err(Error::FontLoadC2PATableTruncated);
+                return Err(wrap_font_err(FontError::FontLoadC2PATableTruncated));
             }
             // If a remote manifest URI is present, unpack it from the remaining
             // data in the table.
@@ -405,7 +458,7 @@ impl TableC2PA {
                 reader.read_exact(&mut uri_bytes)?;
                 active_manifest_uri = Some(
                     from_utf8(&uri_bytes)
-                        .map_err(|_e| Error::FontLoadC2PATableInvalidUtf8)?
+                        .map_err(|_e| FontError::FontLoadC2PATableInvalidUtf8)?
                         .to_string(),
                 );
             }
@@ -535,7 +588,7 @@ impl TableHead {
         reader.seek(SeekFrom::Start(offset))?;
         let actual_size = size_of::<TableHead>();
         if size != actual_size {
-            Err(Error::FontLoadHeadTableBadMissing)
+            Err(wrap_font_err(FontError::FontLoadHeadTableBadMissing))
         } else {
             let head = Self {
                 // 0x00
@@ -586,7 +639,7 @@ impl TableHead {
                 // stream is left, so we don't do anything, since that is simplest.
             };
             if head.magicNumber != HEAD_TABLE_MAGICNUMBER {
-                return Err(Error::FontLoadHeadTableBadMissing);
+                return Err(wrap_font_err(FontError::FontLoadHeadTableBadMissing));
             }
             Ok(head)
         }
@@ -681,7 +734,7 @@ impl TableUnspecified {
         reader: &mut T,
         offset: u64,
         size: usize,
-    ) -> core::result::Result<TableUnspecified, Error> {
+    ) -> Result<TableUnspecified> {
         let mut raw_table_data: Vec<u8> = vec![0; size];
         reader.seek(SeekFrom::Start(offset))?;
         reader.read_exact(&mut raw_table_data)?;
@@ -703,13 +756,13 @@ impl Table for TableUnspecified {
     fn write<TDest: Write + ?Sized>(&self, destination: &mut TDest) -> Result<()> {
         destination
             .write_all(&self.data[..])
-            .map_err(|_e| Error::FontSaveError)?;
+            .map_err(|_e| FontError::FontSaveError)?;
         let limit = self.data.len() % 4;
         if limit > 0 {
             let pad: [u8; 3] = [0, 0, 0];
             destination
                 .write_all(&pad[0..(4 - limit)])
-                .map_err(|_e| Error::FontSaveError)?;
+                .map_err(|_e| FontError::FontSaveError)?;
         }
         Ok(())
     }
@@ -814,7 +867,7 @@ pub(crate) struct SfntDirectoryEntry {
 pub mod tests {
     #![allow(clippy::unwrap_used)]
 
-    use std::{any::Any, io::Cursor};
+    use std::io::Cursor;
 
     use claims::*;
 
@@ -995,7 +1048,10 @@ pub mod tests {
         let mut head_stream: Cursor<&[u8]> = Cursor::<&[u8]>::new(&head_data);
         assert_eq!(size_of::<TableHead>(), head_data.len());
         let head = TableHead::from_reader(&mut head_stream, 0, head_data.len());
-        assert!(head.is_err_and(|e| e.type_id() == Error::FontLoadHeadTableBadMissing.type_id()));
+        matches!(
+            head,
+            Err(Error::FontError(FontError::FontLoadHeadTableBadMissing))
+        );
     }
 
     #[test]
@@ -1020,7 +1076,10 @@ pub mod tests {
         let mut head_stream: Cursor<&[u8]> = Cursor::<&[u8]>::new(&head_data);
         assert_eq!(size_of::<TableHead>(), head_data.len() + 1);
         let head = TableHead::from_reader(&mut head_stream, 0, head_data.len());
-        assert!(head.is_err_and(|e| e.type_id() == Error::FontLoadHeadTableBadMissing.type_id()));
+        matches!(
+            head,
+            Err(Error::FontError(FontError::FontLoadHeadTableBadMissing))
+        );
     }
 
     #[test]

--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -1048,7 +1048,7 @@ pub mod tests {
         let mut head_stream: Cursor<&[u8]> = Cursor::<&[u8]>::new(&head_data);
         assert_eq!(size_of::<TableHead>(), head_data.len());
         let head = TableHead::from_reader(&mut head_stream, 0, head_data.len());
-        matches!(
+        assert_matches!(
             head,
             Err(Error::FontError(FontError::FontLoadHeadTableBadMissing))
         );
@@ -1076,7 +1076,7 @@ pub mod tests {
         let mut head_stream: Cursor<&[u8]> = Cursor::<&[u8]>::new(&head_data);
         assert_eq!(size_of::<TableHead>(), head_data.len() + 1);
         let head = TableHead::from_reader(&mut head_stream, 0, head_data.len());
-        matches!(
+        assert_matches!(
             head,
             Err(Error::FontError(FontError::FontLoadHeadTableBadMissing))
         );

--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -63,7 +63,7 @@ pub enum FontError {
 
     /// Invalid font format
     #[error("Failed to load font")]
-    UnsupportedFontError,
+    UnsupportedFont,
 }
 
 /// Helper method for wrapping a FontError into a crate level error.

--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -61,8 +61,8 @@ pub enum FontError {
     #[error("Unknown font format, the 'magic' number is not recognized.")]
     UnknownMagic,
 
-    /// Invalid font format
-    #[error("Failed to load font")]
+    /// Invalid or unsupported font format
+    #[error("Invalid or unsupported font format")]
     Unsupported,
 }
 

--- a/sdk/src/asset_handlers/sfnt_io.rs
+++ b/sdk/src/asset_handlers/sfnt_io.rs
@@ -322,7 +322,7 @@ impl SfntFont {
                     size_of::<SfntDirectoryEntry>() as i64
                 } else {
                     // We added some other number of tables
-                    return Err(Error::FontSaveError);
+                    return Err(wrap_font_err(FontError::FontSaveError));
                 }
             }
             Ordering::Equal => 0,
@@ -332,13 +332,13 @@ impl SfntFont {
                     // the C2PA table - that's the only one we should ever
                     // be removing.
                     if self.tables.contains_key(&C2PA_TABLE_TAG) {
-                        return Err(Error::FontSaveError);
+                        return Err(wrap_font_err(FontError::FontSaveError));
                     }
                     // We removed exactly one table
                     -(size_of::<SfntDirectoryEntry>() as i64)
                 } else {
                     // We added some other number of tables. Weird, right?
-                    return Err(Error::FontSaveError);
+                    return Err(wrap_font_err(FontError::FontSaveError));
                 }
             }
         };
@@ -370,7 +370,7 @@ impl SfntFont {
                     // be the case where we're removing the C2PA table; the
                     // bias *must not* be negative.
                     if entry.tag == C2PA_TABLE_TAG && td_derived_offset_bias < 0 {
-                        return Err(Error::FontSaveError);
+                        return Err(wrap_font_err(FontError::FontSaveError));
                     }
                     let neo_entry = SfntDirectoryEntry {
                         tag: entry.tag,
@@ -391,7 +391,7 @@ impl SfntFont {
                         // Check - this *must* be the case where we're adding
                         // a C2PA table - therefore the bias should be positive.
                         if td_derived_offset_bias <= 0 {
-                            return Err(Error::FontSaveError);
+                            return Err(wrap_font_err(FontError::FontSaveError));
                         }
                         let neo_entry = SfntDirectoryEntry {
                             tag: *tag,
@@ -407,7 +407,7 @@ impl SfntFont {
                         //    align_to_four(entry.offset as usize + entry.length as usize);
                     }
                     _ => {
-                        return Err(Error::FontSaveError);
+                        return Err(wrap_font_err(FontError::FontSaveError));
                     }
                 },
             }
@@ -808,7 +808,7 @@ where
     TDest: Write + ?Sized,
 {
     source.rewind()?;
-    let mut font = SfntFont::from_reader(source).map_err(|_| Error::FontLoadError)?;
+    let mut font = SfntFont::from_reader(source).map_err(|_| FontError::FontLoadError)?;
     // Install the provide active_manifest_uri in this font's C2PA table, adding
     // that table if needed.
     match font.tables.get_mut(&C2PA_TABLE_TAG) {
@@ -824,10 +824,11 @@ where
         Some(NamedTable::C2PA(c2pa)) => c2pa.manifest_store = Some(manifest_store_data.to_vec()),
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
-            return Err(Error::FontLoadError);
+            return Err(wrap_font_err(FontError::FontLoadError));
         }
     };
-    font.write(destination).map_err(|_| Error::FontSaveError)?;
+    font.write(destination)
+        .map_err(|_| FontError::FontSaveError)?;
     Ok(())
 }
 
@@ -852,7 +853,7 @@ where
     TDest: Write + ?Sized,
 {
     source.rewind()?;
-    let mut font = SfntFont::from_reader(source).map_err(|_| Error::FontLoadError)?;
+    let mut font = SfntFont::from_reader(source).map_err(|_| FontError::FontLoadError)?;
     // Install the provide active_manifest_uri in this font's C2PA table, adding
     // that table if needed.
     match font.tables.get_mut(&C2PA_TABLE_TAG) {
@@ -868,10 +869,11 @@ where
         Some(NamedTable::C2PA(c2pa)) => c2pa.active_manifest_uri = Some(manifest_uri.to_string()),
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
-            return Err(Error::FontLoadError);
+            return Err(wrap_font_err(FontError::FontLoadError));
         }
     };
-    font.write(destination).map_err(|_| Error::FontSaveError)?;
+    font.write(destination)
+        .map_err(|_| FontError::FontSaveError)?;
     Ok(())
 }
 
@@ -891,7 +893,7 @@ where
     TWriter: Read + Seek + ?Sized + Write,
 {
     // Read the font from the input stream
-    let mut font = SfntFont::from_reader(input_stream).map_err(|_| Error::FontLoadError)?;
+    let mut font = SfntFont::from_reader(input_stream).map_err(|_| FontError::FontLoadError)?;
     // If the C2PA table does not exist...
     if font.tables.get(&C2PA_TABLE_TAG).is_none() {
         // ...install an empty one.
@@ -899,7 +901,7 @@ where
     }
     // Write the font to the output stream
     font.write(output_stream)
-        .map_err(|_| Error::FontSaveError)?;
+        .map_err(|_| FontError::FontSaveError)?;
     Ok(())
 }
 
@@ -942,7 +944,7 @@ where
     match read_c2pa_from_stream(source) {
         Ok(c2pa_data) => Ok(c2pa_data.active_manifest_uri),
         Err(Error::JumbfNotFound) => Ok(None),
-        Err(_) => Err(Error::DeserializationError),
+        Err(_) => Err(wrap_font_err(FontError::DeserializationError)),
     }
 }
 
@@ -966,11 +968,12 @@ where
 {
     source.rewind()?;
     // Load the font from the stream
-    let mut font = SfntFont::from_reader(source).map_err(|_| Error::FontLoadError)?;
+    let mut font = SfntFont::from_reader(source).map_err(|_| FontError::FontLoadError)?;
     // Remove the table from the collection
     font.tables.remove(&C2PA_TABLE_TAG);
     // And write it to the destination stream
-    font.write(destination).map_err(|_| Error::FontSaveError)?;
+    font.write(destination)
+        .map_err(|_| FontError::FontSaveError)?;
     Ok(())
 }
 
@@ -987,7 +990,7 @@ where
     TDest: Write + ?Sized,
 {
     source.rewind()?;
-    let mut font = SfntFont::from_reader(source).map_err(|_| Error::FontLoadError)?;
+    let mut font = SfntFont::from_reader(source).map_err(|_| FontError::FontLoadError)?;
     let old_manifest_uri_maybe = match font.tables.get_mut(&C2PA_TABLE_TAG) {
         // If there isn't one, how pleasant, there will be so much less to do.
         None => None,
@@ -1005,10 +1008,11 @@ where
         }
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
-            return Err(Error::FontLoadError);
+            return Err(wrap_font_err(FontError::FontLoadError));
         }
     };
-    font.write(destination).map_err(|_| Error::FontSaveError)?;
+    font.write(destination)
+        .map_err(|_| FontError::FontSaveError)?;
     Ok(old_manifest_uri_maybe)
 }
 
@@ -1076,14 +1080,14 @@ where
 /// Reads the `C2PA` font table from the data stream, returning the `C2PA` font
 /// table data
 fn read_c2pa_from_stream<T: Read + Seek + ?Sized>(reader: &mut T) -> Result<TableC2PA> {
-    let sfnt = SfntFont::from_reader(reader).map_err(|_| Error::FontLoadError)?;
+    let sfnt = SfntFont::from_reader(reader).map_err(|_| FontError::FontLoadError)?;
     match sfnt.tables.get(&C2PA_TABLE_TAG) {
         None => Err(Error::JumbfNotFound),
         // If there is, replace its `manifest_store` value with the
         // provided one.
         Some(NamedTable::C2PA(c2pa)) => Ok(c2pa.clone()),
         // Yikes! Non-C2PA table with C2PA tag!
-        Some(_) => Err(Error::FontLoadError),
+        Some(_) => Err(wrap_font_err(FontError::FontLoadError)),
     }
 }
 

--- a/sdk/src/asset_handlers/sfnt_io.rs
+++ b/sdk/src/asset_handlers/sfnt_io.rs
@@ -322,7 +322,7 @@ impl SfntFont {
                     size_of::<SfntDirectoryEntry>() as i64
                 } else {
                     // We added some other number of tables
-                    return Err(wrap_font_err(FontError::FontSaveError));
+                    return Err(wrap_font_err(FontError::SaveError));
                 }
             }
             Ordering::Equal => 0,
@@ -332,13 +332,13 @@ impl SfntFont {
                     // the C2PA table - that's the only one we should ever
                     // be removing.
                     if self.tables.contains_key(&C2PA_TABLE_TAG) {
-                        return Err(wrap_font_err(FontError::FontSaveError));
+                        return Err(wrap_font_err(FontError::SaveError));
                     }
                     // We removed exactly one table
                     -(size_of::<SfntDirectoryEntry>() as i64)
                 } else {
                     // We added some other number of tables. Weird, right?
-                    return Err(wrap_font_err(FontError::FontSaveError));
+                    return Err(wrap_font_err(FontError::SaveError));
                 }
             }
         };
@@ -370,7 +370,7 @@ impl SfntFont {
                     // be the case where we're removing the C2PA table; the
                     // bias *must not* be negative.
                     if entry.tag == C2PA_TABLE_TAG && td_derived_offset_bias < 0 {
-                        return Err(wrap_font_err(FontError::FontSaveError));
+                        return Err(wrap_font_err(FontError::SaveError));
                     }
                     let neo_entry = SfntDirectoryEntry {
                         tag: entry.tag,
@@ -391,7 +391,7 @@ impl SfntFont {
                         // Check - this *must* be the case where we're adding
                         // a C2PA table - therefore the bias should be positive.
                         if td_derived_offset_bias <= 0 {
-                            return Err(wrap_font_err(FontError::FontSaveError));
+                            return Err(wrap_font_err(FontError::SaveError));
                         }
                         let neo_entry = SfntDirectoryEntry {
                             tag: *tag,
@@ -407,7 +407,7 @@ impl SfntFont {
                         //    align_to_four(entry.offset as usize + entry.length as usize);
                     }
                     _ => {
-                        return Err(wrap_font_err(FontError::FontSaveError));
+                        return Err(wrap_font_err(FontError::SaveError));
                     }
                 },
             }
@@ -808,7 +808,7 @@ where
     TDest: Write + ?Sized,
 {
     source.rewind()?;
-    let mut font = SfntFont::from_reader(source).map_err(|_| FontError::FontLoadError)?;
+    let mut font = SfntFont::from_reader(source).map_err(|_| FontError::LoadError)?;
     // Install the provide active_manifest_uri in this font's C2PA table, adding
     // that table if needed.
     match font.tables.get_mut(&C2PA_TABLE_TAG) {
@@ -824,11 +824,11 @@ where
         Some(NamedTable::C2PA(c2pa)) => c2pa.manifest_store = Some(manifest_store_data.to_vec()),
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
-            return Err(wrap_font_err(FontError::FontLoadError));
+            return Err(wrap_font_err(FontError::LoadError));
         }
     };
     font.write(destination)
-        .map_err(|_| FontError::FontSaveError)?;
+        .map_err(|_| FontError::SaveError)?;
     Ok(())
 }
 
@@ -853,7 +853,7 @@ where
     TDest: Write + ?Sized,
 {
     source.rewind()?;
-    let mut font = SfntFont::from_reader(source).map_err(|_| FontError::FontLoadError)?;
+    let mut font = SfntFont::from_reader(source).map_err(|_| FontError::LoadError)?;
     // Install the provide active_manifest_uri in this font's C2PA table, adding
     // that table if needed.
     match font.tables.get_mut(&C2PA_TABLE_TAG) {
@@ -869,11 +869,11 @@ where
         Some(NamedTable::C2PA(c2pa)) => c2pa.active_manifest_uri = Some(manifest_uri.to_string()),
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
-            return Err(wrap_font_err(FontError::FontLoadError));
+            return Err(wrap_font_err(FontError::LoadError));
         }
     };
     font.write(destination)
-        .map_err(|_| FontError::FontSaveError)?;
+        .map_err(|_| FontError::SaveError)?;
     Ok(())
 }
 
@@ -893,7 +893,7 @@ where
     TWriter: Read + Seek + ?Sized + Write,
 {
     // Read the font from the input stream
-    let mut font = SfntFont::from_reader(input_stream).map_err(|_| FontError::FontLoadError)?;
+    let mut font = SfntFont::from_reader(input_stream).map_err(|_| FontError::LoadError)?;
     // If the C2PA table does not exist...
     if font.tables.get(&C2PA_TABLE_TAG).is_none() {
         // ...install an empty one.
@@ -901,7 +901,7 @@ where
     }
     // Write the font to the output stream
     font.write(output_stream)
-        .map_err(|_| FontError::FontSaveError)?;
+        .map_err(|_| FontError::SaveError)?;
     Ok(())
 }
 
@@ -968,12 +968,12 @@ where
 {
     source.rewind()?;
     // Load the font from the stream
-    let mut font = SfntFont::from_reader(source).map_err(|_| FontError::FontLoadError)?;
+    let mut font = SfntFont::from_reader(source).map_err(|_| FontError::LoadError)?;
     // Remove the table from the collection
     font.tables.remove(&C2PA_TABLE_TAG);
     // And write it to the destination stream
     font.write(destination)
-        .map_err(|_| FontError::FontSaveError)?;
+        .map_err(|_| FontError::SaveError)?;
     Ok(())
 }
 
@@ -990,7 +990,7 @@ where
     TDest: Write + ?Sized,
 {
     source.rewind()?;
-    let mut font = SfntFont::from_reader(source).map_err(|_| FontError::FontLoadError)?;
+    let mut font = SfntFont::from_reader(source).map_err(|_| FontError::LoadError)?;
     let old_manifest_uri_maybe = match font.tables.get_mut(&C2PA_TABLE_TAG) {
         // If there isn't one, how pleasant, there will be so much less to do.
         None => None,
@@ -1008,11 +1008,11 @@ where
         }
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
-            return Err(wrap_font_err(FontError::FontLoadError));
+            return Err(wrap_font_err(FontError::LoadError));
         }
     };
     font.write(destination)
-        .map_err(|_| FontError::FontSaveError)?;
+        .map_err(|_| FontError::SaveError)?;
     Ok(old_manifest_uri_maybe)
 }
 
@@ -1080,14 +1080,14 @@ where
 /// Reads the `C2PA` font table from the data stream, returning the `C2PA` font
 /// table data
 fn read_c2pa_from_stream<T: Read + Seek + ?Sized>(reader: &mut T) -> Result<TableC2PA> {
-    let sfnt = SfntFont::from_reader(reader).map_err(|_| FontError::FontLoadError)?;
+    let sfnt = SfntFont::from_reader(reader).map_err(|_| FontError::LoadError)?;
     match sfnt.tables.get(&C2PA_TABLE_TAG) {
         None => Err(Error::JumbfNotFound),
         // If there is, replace its `manifest_store` value with the
         // provided one.
         Some(NamedTable::C2PA(c2pa)) => Ok(c2pa.clone()),
         // Yikes! Non-C2PA table with C2PA tag!
-        Some(_) => Err(wrap_font_err(FontError::FontLoadError)),
+        Some(_) => Err(wrap_font_err(FontError::LoadError)),
     }
 }
 

--- a/sdk/src/asset_handlers/sfnt_io.rs
+++ b/sdk/src/asset_handlers/sfnt_io.rs
@@ -827,8 +827,7 @@ where
             return Err(wrap_font_err(FontError::LoadError));
         }
     };
-    font.write(destination)
-        .map_err(|_| FontError::SaveError)?;
+    font.write(destination).map_err(|_| FontError::SaveError)?;
     Ok(())
 }
 
@@ -872,8 +871,7 @@ where
             return Err(wrap_font_err(FontError::LoadError));
         }
     };
-    font.write(destination)
-        .map_err(|_| FontError::SaveError)?;
+    font.write(destination).map_err(|_| FontError::SaveError)?;
     Ok(())
 }
 
@@ -972,8 +970,7 @@ where
     // Remove the table from the collection
     font.tables.remove(&C2PA_TABLE_TAG);
     // And write it to the destination stream
-    font.write(destination)
-        .map_err(|_| FontError::SaveError)?;
+    font.write(destination).map_err(|_| FontError::SaveError)?;
     Ok(())
 }
 
@@ -1011,8 +1008,7 @@ where
             return Err(wrap_font_err(FontError::LoadError));
         }
     };
-    font.write(destination)
-        .map_err(|_| FontError::SaveError)?;
+    font.write(destination).map_err(|_| FontError::SaveError)?;
     Ok(old_manifest_uri_maybe)
 }
 

--- a/sdk/src/asset_handlers/woff_io.rs
+++ b/sdk/src/asset_handlers/woff_io.rs
@@ -680,7 +680,7 @@ impl ChunkReader for WoffIO {
         // TBD - Push this into WoffHeader::from_reader
         let _font_magic: Magic =
             <u32 as std::convert::TryInto<Magic>>::try_into(woff_hdr.signature)
-                .map_err(|_err| Error::UnsupportedFontError)?;
+                .map_err(|_err| FontError::UnsupportedFontError)?;
         // Add the position of the header.
         let mut positions: Vec<ChunkPosition> = Vec::new();
         positions.push(ChunkPosition {
@@ -763,7 +763,7 @@ where
     TDest: Write + ?Sized,
 {
     source.rewind()?;
-    let mut font = WoffFont::from_reader(source).map_err(|_| Error::FontLoadError)?;
+    let mut font = WoffFont::from_reader(source).map_err(|_| FontError::FontLoadError)?;
     // Install the provide active_manifest_uri in this font's C2PA table, adding
     // that table if needed.
     match font.tables.get_mut(&C2PA_TABLE_TAG) {
@@ -777,10 +777,11 @@ where
         Some(NamedTable::C2PA(c2pa)) => c2pa.manifest_store = Some(manifest_store_data.to_vec()),
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
-            return Err(Error::FontLoadError);
+            return Err(wrap_font_err(FontError::FontLoadError));
         }
     };
-    font.write(destination).map_err(|_| Error::FontSaveError)?;
+    font.write(destination)
+        .map_err(|_| FontError::FontSaveError)?;
     Ok(())
 }
 
@@ -805,7 +806,7 @@ where
     TDest: Write + ?Sized,
 {
     source.rewind()?;
-    let mut font = WoffFont::from_reader(source).map_err(|_| Error::FontLoadError)?;
+    let mut font = WoffFont::from_reader(source).map_err(|_| FontError::FontLoadError)?;
     // Install the provide active_manifest_uri in this font's C2PA table, adding
     // that table if needed.
     match font.tables.get_mut(&C2PA_TABLE_TAG) {
@@ -821,10 +822,11 @@ where
         Some(NamedTable::C2PA(c2pa)) => c2pa.active_manifest_uri = Some(manifest_uri.to_string()),
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
-            return Err(Error::FontLoadError);
+            return Err(wrap_font_err(FontError::FontLoadError));
         }
     };
-    font.write(destination).map_err(|_| Error::FontSaveError)?;
+    font.write(destination)
+        .map_err(|_| FontError::FontSaveError)?;
     Ok(())
 }
 
@@ -844,7 +846,7 @@ where
     TWriter: Read + Seek + ?Sized + Write,
 {
     // Read the font from the input stream
-    let mut font = WoffFont::from_reader(input_stream).map_err(|_| Error::FontLoadError)?;
+    let mut font = WoffFont::from_reader(input_stream).map_err(|_| FontError::FontLoadError)?;
     // If the C2PA table does not exist...
     if font.tables.get(&C2PA_TABLE_TAG).is_none() {
         // ...install an empty one.
@@ -852,7 +854,7 @@ where
     }
     // Write the font to the output stream
     font.write(output_stream)
-        .map_err(|_| Error::FontSaveError)?;
+        .map_err(|_| FontError::FontSaveError)?;
     Ok(())
 }
 
@@ -895,7 +897,7 @@ where
     match read_c2pa_from_stream(source) {
         Ok(c2pa_data) => Ok(c2pa_data.active_manifest_uri),
         Err(Error::JumbfNotFound) => Ok(None),
-        Err(_) => Err(Error::DeserializationError),
+        Err(_) => Err(wrap_font_err(FontError::DeserializationError)),
     }
 }
 
@@ -919,11 +921,12 @@ where
 {
     source.rewind()?;
     // Load the font from the stream
-    let mut font = WoffFont::from_reader(source).map_err(|_| Error::FontLoadError)?;
+    let mut font = WoffFont::from_reader(source).map_err(|_| FontError::FontLoadError)?;
     // Remove the table from the collection
     font.tables.remove(&C2PA_TABLE_TAG);
     // And write it to the destination stream
-    font.write(destination).map_err(|_| Error::FontSaveError)?;
+    font.write(destination)
+        .map_err(|_| FontError::FontSaveError)?;
 
     Ok(())
 }
@@ -941,7 +944,7 @@ where
     TDest: Write + ?Sized,
 {
     source.rewind()?;
-    let mut font = WoffFont::from_reader(source).map_err(|_| Error::FontLoadError)?;
+    let mut font = WoffFont::from_reader(source).map_err(|_| FontError::FontLoadError)?;
     let old_manifest_uri_maybe = match font.tables.get_mut(&C2PA_TABLE_TAG) {
         // If there isn't one, how pleasant, there will be so much less to do.
         None => None,
@@ -959,10 +962,11 @@ where
         }
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
-            return Err(Error::FontLoadError);
+            return Err(wrap_font_err(FontError::FontLoadError));
         }
     };
-    font.write(destination).map_err(|_| Error::FontSaveError)?;
+    font.write(destination)
+        .map_err(|_| FontError::FontSaveError)?;
     Ok(old_manifest_uri_maybe)
 }
 
@@ -1071,7 +1075,7 @@ where
 /// Reads the `C2PA` font table from the data stream, returning the `C2PA` font
 /// table data
 fn read_c2pa_from_stream<T: Read + Seek + ?Sized>(reader: &mut T) -> Result<TableC2PA> {
-    let woff = WoffFont::from_reader(reader).map_err(|_| Error::FontLoadError)?;
+    let woff = WoffFont::from_reader(reader).map_err(|_| FontError::FontLoadError)?;
     let c2pa_table: Option<TableC2PA> = match woff.tables.get(&C2PA_TABLE_TAG) {
         None => None,
         // If there is, replace its `manifest_store` value with the
@@ -1079,7 +1083,7 @@ fn read_c2pa_from_stream<T: Read + Seek + ?Sized>(reader: &mut T) -> Result<Tabl
         Some(NamedTable::C2PA(c2pa)) => Some(c2pa.clone()),
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
-            return Err(Error::FontLoadError);
+            return Err(wrap_font_err(FontError::FontLoadError));
         }
     };
     c2pa_table.ok_or(Error::JumbfNotFound)

--- a/sdk/src/asset_handlers/woff_io.rs
+++ b/sdk/src/asset_handlers/woff_io.rs
@@ -680,7 +680,7 @@ impl ChunkReader for WoffIO {
         // TBD - Push this into WoffHeader::from_reader
         let _font_magic: Magic =
             <u32 as std::convert::TryInto<Magic>>::try_into(woff_hdr.signature)
-                .map_err(|_err| FontError::UnsupportedFont)?;
+                .map_err(|_err| FontError::Unsupported)?;
         // Add the position of the header.
         let mut positions: Vec<ChunkPosition> = Vec::new();
         positions.push(ChunkPosition {
@@ -763,7 +763,7 @@ where
     TDest: Write + ?Sized,
 {
     source.rewind()?;
-    let mut font = WoffFont::from_reader(source).map_err(|_| FontError::FontLoadError)?;
+    let mut font = WoffFont::from_reader(source).map_err(|_| FontError::LoadError)?;
     // Install the provide active_manifest_uri in this font's C2PA table, adding
     // that table if needed.
     match font.tables.get_mut(&C2PA_TABLE_TAG) {
@@ -777,11 +777,11 @@ where
         Some(NamedTable::C2PA(c2pa)) => c2pa.manifest_store = Some(manifest_store_data.to_vec()),
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
-            return Err(wrap_font_err(FontError::FontLoadError));
+            return Err(wrap_font_err(FontError::LoadError));
         }
     };
     font.write(destination)
-        .map_err(|_| FontError::FontSaveError)?;
+        .map_err(|_| FontError::SaveError)?;
     Ok(())
 }
 
@@ -806,7 +806,7 @@ where
     TDest: Write + ?Sized,
 {
     source.rewind()?;
-    let mut font = WoffFont::from_reader(source).map_err(|_| FontError::FontLoadError)?;
+    let mut font = WoffFont::from_reader(source).map_err(|_| FontError::LoadError)?;
     // Install the provide active_manifest_uri in this font's C2PA table, adding
     // that table if needed.
     match font.tables.get_mut(&C2PA_TABLE_TAG) {
@@ -822,11 +822,11 @@ where
         Some(NamedTable::C2PA(c2pa)) => c2pa.active_manifest_uri = Some(manifest_uri.to_string()),
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
-            return Err(wrap_font_err(FontError::FontLoadError));
+            return Err(wrap_font_err(FontError::LoadError));
         }
     };
     font.write(destination)
-        .map_err(|_| FontError::FontSaveError)?;
+        .map_err(|_| FontError::SaveError)?;
     Ok(())
 }
 
@@ -846,7 +846,7 @@ where
     TWriter: Read + Seek + ?Sized + Write,
 {
     // Read the font from the input stream
-    let mut font = WoffFont::from_reader(input_stream).map_err(|_| FontError::FontLoadError)?;
+    let mut font = WoffFont::from_reader(input_stream).map_err(|_| FontError::LoadError)?;
     // If the C2PA table does not exist...
     if font.tables.get(&C2PA_TABLE_TAG).is_none() {
         // ...install an empty one.
@@ -854,7 +854,7 @@ where
     }
     // Write the font to the output stream
     font.write(output_stream)
-        .map_err(|_| FontError::FontSaveError)?;
+        .map_err(|_| FontError::SaveError)?;
     Ok(())
 }
 
@@ -921,12 +921,12 @@ where
 {
     source.rewind()?;
     // Load the font from the stream
-    let mut font = WoffFont::from_reader(source).map_err(|_| FontError::FontLoadError)?;
+    let mut font = WoffFont::from_reader(source).map_err(|_| FontError::LoadError)?;
     // Remove the table from the collection
     font.tables.remove(&C2PA_TABLE_TAG);
     // And write it to the destination stream
     font.write(destination)
-        .map_err(|_| FontError::FontSaveError)?;
+        .map_err(|_| FontError::SaveError)?;
 
     Ok(())
 }
@@ -944,7 +944,7 @@ where
     TDest: Write + ?Sized,
 {
     source.rewind()?;
-    let mut font = WoffFont::from_reader(source).map_err(|_| FontError::FontLoadError)?;
+    let mut font = WoffFont::from_reader(source).map_err(|_| FontError::LoadError)?;
     let old_manifest_uri_maybe = match font.tables.get_mut(&C2PA_TABLE_TAG) {
         // If there isn't one, how pleasant, there will be so much less to do.
         None => None,
@@ -962,11 +962,11 @@ where
         }
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
-            return Err(wrap_font_err(FontError::FontLoadError));
+            return Err(wrap_font_err(FontError::LoadError));
         }
     };
     font.write(destination)
-        .map_err(|_| FontError::FontSaveError)?;
+        .map_err(|_| FontError::SaveError)?;
     Ok(old_manifest_uri_maybe)
 }
 
@@ -1075,7 +1075,7 @@ where
 /// Reads the `C2PA` font table from the data stream, returning the `C2PA` font
 /// table data
 fn read_c2pa_from_stream<T: Read + Seek + ?Sized>(reader: &mut T) -> Result<TableC2PA> {
-    let woff = WoffFont::from_reader(reader).map_err(|_| FontError::FontLoadError)?;
+    let woff = WoffFont::from_reader(reader).map_err(|_| FontError::LoadError)?;
     let c2pa_table: Option<TableC2PA> = match woff.tables.get(&C2PA_TABLE_TAG) {
         None => None,
         // If there is, replace its `manifest_store` value with the
@@ -1083,7 +1083,7 @@ fn read_c2pa_from_stream<T: Read + Seek + ?Sized>(reader: &mut T) -> Result<Tabl
         Some(NamedTable::C2PA(c2pa)) => Some(c2pa.clone()),
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
-            return Err(wrap_font_err(FontError::FontLoadError));
+            return Err(wrap_font_err(FontError::LoadError));
         }
     };
     c2pa_table.ok_or(Error::JumbfNotFound)

--- a/sdk/src/asset_handlers/woff_io.rs
+++ b/sdk/src/asset_handlers/woff_io.rs
@@ -780,8 +780,7 @@ where
             return Err(wrap_font_err(FontError::LoadError));
         }
     };
-    font.write(destination)
-        .map_err(|_| FontError::SaveError)?;
+    font.write(destination).map_err(|_| FontError::SaveError)?;
     Ok(())
 }
 
@@ -825,8 +824,7 @@ where
             return Err(wrap_font_err(FontError::LoadError));
         }
     };
-    font.write(destination)
-        .map_err(|_| FontError::SaveError)?;
+    font.write(destination).map_err(|_| FontError::SaveError)?;
     Ok(())
 }
 
@@ -925,8 +923,7 @@ where
     // Remove the table from the collection
     font.tables.remove(&C2PA_TABLE_TAG);
     // And write it to the destination stream
-    font.write(destination)
-        .map_err(|_| FontError::SaveError)?;
+    font.write(destination).map_err(|_| FontError::SaveError)?;
 
     Ok(())
 }
@@ -965,8 +962,7 @@ where
             return Err(wrap_font_err(FontError::LoadError));
         }
     };
-    font.write(destination)
-        .map_err(|_| FontError::SaveError)?;
+    font.write(destination).map_err(|_| FontError::SaveError)?;
     Ok(old_manifest_uri_maybe)
 }
 

--- a/sdk/src/asset_handlers/woff_io.rs
+++ b/sdk/src/asset_handlers/woff_io.rs
@@ -680,7 +680,7 @@ impl ChunkReader for WoffIO {
         // TBD - Push this into WoffHeader::from_reader
         let _font_magic: Magic =
             <u32 as std::convert::TryInto<Magic>>::try_into(woff_hdr.signature)
-                .map_err(|_err| FontError::UnsupportedFontError)?;
+                .map_err(|_err| FontError::UnsupportedFont)?;
         // Add the position of the header.
         let mut positions: Vec<ChunkPosition> = Vec::new();
         positions.push(ChunkPosition {

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -150,6 +150,7 @@ pub enum Error {
     #[error("COSE Signature too big for JUMBF box")]
     CoseSigboxTooSmall,
 
+    #[cfg(feature = "font")]
     #[error("Font error: {0}")]
     FontError(#[from] crate::asset_handlers::font_io::FontError),
 

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -150,6 +150,9 @@ pub enum Error {
     #[error("COSE Signature too big for JUMBF box")]
     CoseSigboxTooSmall,
 
+    #[error("Font error: {0}")]
+    FontError(#[from] crate::asset_handlers::font_io::FontError),
+
     #[error("WASM verifier error")]
     WasmVerifier,
 
@@ -275,38 +278,6 @@ pub enum Error {
 
     #[error(transparent)]
     OtherError(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
-
-    #[error("Failed to load font")]
-    FontLoadError,
-
-    #[error("C2PA table bad or missing")]
-    FontLoadC2PATableBadMissing,
-
-    #[error("C2PA table manifest data is not valid UTF-8")]
-    FontLoadC2PATableInvalidUtf8,
-
-    #[error("C2PA table claimed sizes exceed actual")]
-    FontLoadC2PATableTruncated,
-
-    #[error("head table bad or missing")]
-    FontLoadHeadTableBadMissing,
-
-    #[error("SFNT header bad or missing")]
-    FontLoadSfntHeaderBadMissing,
-
-    #[error("Failed to save font")]
-    FontSaveError,
-
-    #[error("Font has unknown magic number")]
-    FontUnknownMagic,
-
-    /// Failed to parse or de-serialize font data
-    #[error("Failed to de-serialize data")]
-    DeserializationError,
-
-    /// Invalid font format
-    #[error("Failed to load font")]
-    UnsupportedFontError,
 
     #[error("prerelease content detected")]
     PrereleaseError,


### PR DESCRIPTION
## Changes in this pull request
_Give a narrative description of what has been changed._

Following examples in other areas of the library, this moves the font-related errors to the `asset_handlers/font_io.rs` module as:

`enum FontError`.

At this point, keeping the changes small with just the move and keeping the errors the same. This should facilitate a quicker change for the other story which picks up testing in more earnest to be unblocked.

I also noticed the library also has other places with this type of error structure and provides a `wrap_*_err` `fn`, so I did the same to try to stay consistent with the other parts of the library.

## Checklist
- [X] This PR represents a single feature, fix, or change.
- [X] All applicable changes have been documented.
