### PR TITLE
C2PA-305: More detailed font errors

### DIFF
--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -37,10 +37,6 @@ pub enum FontError {
     #[error("Bad head table, unknown data format")]
     BadHeadTable,
 
-    /// Failed to parse or de-serialize font data
-    #[error("Failed to de-serialize data")]
-    DeserializationError,
-
     /// IO error while dealing with a potentially font-related file/stream.
     #[error(transparent)]
     IoError(#[from] std::io::Error),

--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -16,6 +16,7 @@ use std::io::{Read, Seek, SeekFrom, Write};
 
 use asn1_rs::nom::AsBytes;
 use byteorder::{BigEndian, ByteOrder, ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "xmp_write")]
 use xmp_toolkit::XmpError;
 
 use crate::error::Error;

--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -64,12 +64,8 @@ pub enum FontError {
     #[error("head table claimed sizes exceed actual")]
     LoadHeadTableTruncated,
 
-    /// Failed to save the font.
-    #[error("Failed to save font")]
-    SaveError,
-
     #[error("Failed to save font: {0}")]
-    SavveeError(#[from] FontSaveError),
+    SaveError(#[from] FontSaveError),
 
     /// The font is missing a valid 'magic' number, therefore an unknown font type.
     #[error("Unknown font format, the 'magic' number is not recognized.")]

--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -105,10 +105,15 @@ pub enum FontSaveError {
     #[error("Failed to save font because the write operation failed.")]
     FailedToWrite(std::io::Error),
 
-    /// Failed to save a font file with an unexpected number of tables
-    /// found in the font.
-    #[error("Unexpected number of tables.")]
-    UnexpectedNumberOfTables,
+    /// Failed to save a font file due to a state where the font's
+    /// table directory has more than just the 'C2PA' table added.
+    #[error("Too many tables were added to the font, only expected to add one for C2PA.")]
+    TooManyTablesAdded,
+
+    /// Failed to save a font file due to a state where the font's
+    /// table directory has more than just the 'C2PA' table removed.
+    #[error("Too many tables were removed from the font, only expected to remove one for C2PA.")]
+    TooManyTablesRemoved,
 
     /// Failed to save a font file with an unexpected table found in the
     /// table directory.

--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -102,7 +102,7 @@ pub enum FontSaveError {
 
     /// Failed to save a font file due to the fact the write operation
     /// failed.
-    #[error("Failed to save font because the write operation failed.")]
+    #[error("Failed to save font because the write operation failed; {0}")]
     FailedToWrite(std::io::Error),
 
     /// Failed to save a font file due to a state where the font's

--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -40,13 +40,13 @@ pub enum FontError {
     #[error(transparent)]
     IoError(#[from] std::io::Error),
 
+    /// Invalid named table encountered.
+    #[error("Invalid named table: {0}")]
+    InvalidNamedTable(&'static str),
+
     //// The JUMBF data was not found.
     #[error("The JUMBF data was not found.")]
     JumbfNotFound,
-
-    /// Failed to load a font.
-    #[error("Failed to load font")]
-    LoadError,
 
     /// Failed to load the font's 'C2PA' table, either because it was missing or
     /// because it was truncated/bad.

--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -49,7 +49,7 @@ pub enum FontError {
     #[error("Invalid named table: {0}")]
     InvalidNamedTable(&'static str),
 
-    //// The JUMBF data was not found.
+    /// The JUMBF data was not found.
     #[error("The JUMBF data was not found.")]
     JumbfNotFound,
 

--- a/sdk/src/asset_handlers/sfnt_io.rs
+++ b/sdk/src/asset_handlers/sfnt_io.rs
@@ -848,7 +848,7 @@ where
         Some(NamedTable::C2PA(c2pa)) => c2pa.manifest_store = Some(manifest_store_data.to_vec()),
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
-            return Err(FontError::LoadError);
+            return Err(FontError::InvalidNamedTable("Non-C2PA table with C2PA tag"));
         }
     };
     font.write(destination)?;
@@ -895,7 +895,7 @@ where
         Some(NamedTable::C2PA(c2pa)) => c2pa.active_manifest_uri = Some(manifest_uri.to_string()),
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
-            return Err(FontError::LoadError);
+            return Err(FontError::InvalidNamedTable("Non-C2PA table with C2PA tag"));
         }
     };
     font.write(destination).map_err(|_| FontError::SaveError)?;
@@ -918,7 +918,8 @@ where
     TWriter: Read + Seek + ?Sized + Write,
 {
     // Read the font from the input stream
-    let mut font = SfntFont::from_reader(input_stream).map_err(|_| FontError::LoadError)?;
+    let mut font =
+        SfntFont::from_reader(input_stream).map_err(|_| FontError::DeserializationError)?;
     // If the C2PA table does not exist...
     if font.tables.get(&C2PA_TABLE_TAG).is_none() {
         // ...install an empty one.
@@ -971,7 +972,7 @@ where
     match read_c2pa_from_stream(source) {
         Ok(c2pa_data) => Ok(c2pa_data.active_manifest_uri),
         Err(FontError::JumbfNotFound) => Ok(None),
-        Err(_) => Err(FontError::DeserializationError),
+        Err(e) => Err(e),
     }
 }
 
@@ -1034,7 +1035,7 @@ where
         }
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
-            return Err(FontError::LoadError);
+            return Err(FontError::InvalidNamedTable("Non-C2PA table with C2PA tag"));
         }
     };
     font.write(destination)?;
@@ -1104,17 +1105,16 @@ where
 
 /// Reads the `C2PA` font table from the data stream, returning the `C2PA` font
 /// table data
-fn read_c2pa_from_stream<T: Read + Seek + ?Sized>(
-    reader: &mut T,
-) -> core::result::Result<TableC2PA, FontError> {
-    let sfnt = SfntFont::from_reader(reader)?;
+fn read_c2pa_from_stream<T: Read + Seek + ?Sized>(reader: &mut T) -> Result<TableC2PA> {
+    // Convert all errors from the reader to a deserialization error.
+    let sfnt = SfntFont::from_reader(reader).map_err(|_| FontError::DeserializationError)?;
     match sfnt.tables.get(&C2PA_TABLE_TAG) {
         None => Err(FontError::JumbfNotFound),
         // If there is, replace its `manifest_store` value with the
         // provided one.
         Some(NamedTable::C2PA(c2pa)) => Ok(c2pa.clone()),
         // Yikes! Non-C2PA table with C2PA tag!
-        Some(_) => Err(FontError::LoadError),
+        Some(_) => Err(FontError::InvalidNamedTable("Non-C2PA table with C2PA tag")),
     }
 }
 

--- a/sdk/src/asset_handlers/sfnt_io.rs
+++ b/sdk/src/asset_handlers/sfnt_io.rs
@@ -323,7 +323,7 @@ impl SfntFont {
                 } else {
                     // We added some other number of tables
                     return Err(FontError::SaveError(
-                        FontSaveError::UnexpectedNumberOfTables,
+                        FontSaveError::TooManyTablesAdded,
                     ));
                 }
             }
@@ -341,9 +341,9 @@ impl SfntFont {
                     // We removed exactly one table
                     -(size_of::<SfntDirectoryEntry>() as i64)
                 } else {
-                    // We added some other number of tables. Weird, right?
+                    // We removed some other number of tables. Weird, right?
                     return Err(FontError::SaveError(
-                        FontSaveError::UnexpectedNumberOfTables,
+                        FontSaveError::TooManyTablesRemoved,
                     ));
                 }
             }

--- a/sdk/src/asset_handlers/sfnt_io.rs
+++ b/sdk/src/asset_handlers/sfnt_io.rs
@@ -330,7 +330,7 @@ impl SfntFont {
                     size_of::<SfntDirectoryEntry>() as i64
                 } else {
                     // We added some other number of tables
-                    return Err(FontError::SavveeError(
+                    return Err(FontError::SaveError(
                         FontSaveError::UnexpectedNumberOfTables,
                     ));
                 }
@@ -342,7 +342,7 @@ impl SfntFont {
                     // the C2PA table - that's the only one we should ever
                     // be removing.
                     if self.tables.contains_key(&C2PA_TABLE_TAG) {
-                        return Err(FontError::SavveeError(FontSaveError::UnexpectedTable(
+                        return Err(FontError::SaveError(FontSaveError::UnexpectedTable(
                             format!("{:?}", C2PA_TABLE_TAG),
                         )));
                     }
@@ -350,7 +350,7 @@ impl SfntFont {
                     -(size_of::<SfntDirectoryEntry>() as i64)
                 } else {
                     // We added some other number of tables. Weird, right?
-                    return Err(FontError::SavveeError(
+                    return Err(FontError::SaveError(
                         FontSaveError::UnexpectedNumberOfTables,
                     ));
                 }
@@ -384,7 +384,7 @@ impl SfntFont {
                     // be the case where we're removing the C2PA table; the
                     // bias *must not* be negative.
                     if entry.tag == C2PA_TABLE_TAG && td_derived_offset_bias < 0 {
-                        return Err(FontError::SavveeError(
+                        return Err(FontError::SaveError(
                             FontSaveError::InvalidDerivedTableOffsetBias,
                         ));
                     }
@@ -407,7 +407,7 @@ impl SfntFont {
                         // Check - this *must* be the case where we're adding
                         // a C2PA table - therefore the bias should be positive.
                         if td_derived_offset_bias <= 0 {
-                            return Err(FontError::SavveeError(
+                            return Err(FontError::SaveError(
                                 FontSaveError::InvalidDerivedTableOffsetBias,
                             ));
                         }
@@ -425,7 +425,7 @@ impl SfntFont {
                         //    align_to_four(entry.offset as usize + entry.length as usize);
                     }
                     _ => {
-                        return Err(FontError::SavveeError(FontSaveError::UnexpectedTable(
+                        return Err(FontError::SaveError(FontSaveError::UnexpectedTable(
                             format!("{:?}", tag),
                         )))
                     }

--- a/sdk/src/asset_handlers/sfnt_io.rs
+++ b/sdk/src/asset_handlers/sfnt_io.rs
@@ -1136,11 +1136,9 @@ impl SfntIO {
 /// SFNT implementation of the CAILoader trait.
 impl CAIReader for SfntIO {
     fn read_cai(&self, asset_reader: &mut dyn CAIRead) -> crate::error::Result<Vec<u8>> {
-        let c2pa_table = read_c2pa_from_stream(asset_reader).map_err(|e|{
-            match e {
-                FontError::JumbfNotFound => Error::JumbfNotFound,
-                _ => wrap_font_err(e),
-            }
+        let c2pa_table = read_c2pa_from_stream(asset_reader).map_err(|e| match e {
+            FontError::JumbfNotFound => Error::JumbfNotFound,
+            _ => wrap_font_err(e),
         })?;
         match c2pa_table.get_manifest_store() {
             Some(manifest_store) => Ok(manifest_store.to_vec()),

--- a/sdk/src/asset_handlers/sfnt_io.rs
+++ b/sdk/src/asset_handlers/sfnt_io.rs
@@ -322,9 +322,7 @@ impl SfntFont {
                     size_of::<SfntDirectoryEntry>() as i64
                 } else {
                     // We added some other number of tables
-                    return Err(FontError::SaveError(
-                        FontSaveError::TooManyTablesAdded,
-                    ));
+                    return Err(FontError::SaveError(FontSaveError::TooManyTablesAdded));
                 }
             }
             Ordering::Equal => 0,
@@ -342,9 +340,7 @@ impl SfntFont {
                     -(size_of::<SfntDirectoryEntry>() as i64)
                 } else {
                     // We removed some other number of tables. Weird, right?
-                    return Err(FontError::SaveError(
-                        FontSaveError::TooManyTablesRemoved,
-                    ));
+                    return Err(FontError::SaveError(FontSaveError::TooManyTablesRemoved));
                 }
             }
         };

--- a/sdk/src/asset_handlers/sfnt_io.rs
+++ b/sdk/src/asset_handlers/sfnt_io.rs
@@ -1146,18 +1146,14 @@ impl CAIWriter for SfntIO {
         output_stream: &mut dyn CAIReadWrite,
         store_bytes: &[u8],
     ) -> crate::error::Result<()> {
-        Ok(add_c2pa_to_stream(
-            input_stream,
-            output_stream,
-            store_bytes,
-        )?)
+        add_c2pa_to_stream(input_stream, output_stream, store_bytes).map_err(wrap_font_err)
     }
 
     fn get_object_locations_from_stream(
         &self,
         input_stream: &mut dyn CAIRead,
     ) -> crate::error::Result<Vec<HashObjectPositions>> {
-        Ok(get_object_locations_from_stream(self, input_stream)?)
+        get_object_locations_from_stream(self, input_stream).map_err(wrap_font_err)
     }
 
     fn remove_cai_store_from_stream(
@@ -1165,7 +1161,7 @@ impl CAIWriter for SfntIO {
         input_stream: &mut dyn CAIRead,
         output_stream: &mut dyn CAIReadWrite,
     ) -> crate::error::Result<()> {
-        Ok(remove_c2pa_from_stream(input_stream, output_stream)?)
+        remove_c2pa_from_stream(input_stream, output_stream).map_err(wrap_font_err)
     }
 }
 
@@ -1216,7 +1212,7 @@ impl AssetIO for SfntIO {
     }
 
     fn save_cai_store(&self, asset_path: &Path, store_bytes: &[u8]) -> crate::error::Result<()> {
-        Ok(add_c2pa_to_font(asset_path, store_bytes)?)
+        add_c2pa_to_font(asset_path, store_bytes).map_err(wrap_font_err)
     }
 
     fn get_object_locations(
@@ -1224,11 +1220,11 @@ impl AssetIO for SfntIO {
         asset_path: &Path,
     ) -> crate::error::Result<Vec<HashObjectPositions>> {
         let mut buf_reader = open_bufreader_for_file(asset_path)?;
-        Ok(get_object_locations_from_stream(self, &mut buf_reader)?)
+        get_object_locations_from_stream(self, &mut buf_reader).map_err(wrap_font_err)
     }
 
     fn remove_cai_store(&self, asset_path: &Path) -> crate::error::Result<()> {
-        Ok(remove_c2pa_from_font(asset_path)?)
+        remove_c2pa_from_font(asset_path).map_err(wrap_font_err)
     }
 
     fn asset_box_hash_ref(&self) -> Option<&dyn AssetBoxHash> {
@@ -1275,14 +1271,12 @@ impl RemoteRefEmbed for SfntIO {
             crate::asset_io::RemoteRefEmbedType::Xmp(manifest_uri) => {
                 #[cfg(feature = "xmp_write")]
                 {
-                    Ok(font_xmp_support::add_reference_as_xmp_to_font(
-                        asset_path,
-                        &manifest_uri,
-                    )?)
+                    font_xmp_support::add_reference_as_xmp_to_font(asset_path, &manifest_uri)
+                        .map_err(wrap_font_err)
                 }
                 #[cfg(not(feature = "xmp_write"))]
                 {
-                    Ok(add_reference_to_font(asset_path, &manifest_uri)?)
+                    add_reference_to_font(asset_path, &manifest_uri).map_err(wrap_font_err)
                 }
             }
             crate::asset_io::RemoteRefEmbedType::StegoS(_) => Err(Error::UnsupportedType),
@@ -1301,19 +1295,17 @@ impl RemoteRefEmbed for SfntIO {
             crate::asset_io::RemoteRefEmbedType::Xmp(manifest_uri) => {
                 #[cfg(feature = "xmp_write")]
                 {
-                    Ok(font_xmp_support::add_reference_as_xmp_to_stream(
+                    font_xmp_support::add_reference_as_xmp_to_stream(
                         reader,
                         output_stream,
                         &manifest_uri,
-                    )?)
+                    )
+                    .map_err(wrap_font_err)
                 }
                 #[cfg(not(feature = "xmp_write"))]
                 {
-                    Ok(add_reference_to_stream(
-                        reader,
-                        output_stream,
-                        &manifest_uri,
-                    )?)
+                    add_reference_to_stream(reader, output_stream, &manifest_uri)
+                        .map_err(wrap_font_err)
                 }
             }
             crate::asset_io::RemoteRefEmbedType::StegoS(_) => Err(Error::UnsupportedType),

--- a/sdk/src/asset_handlers/sfnt_io.rs
+++ b/sdk/src/asset_handlers/sfnt_io.rs
@@ -903,8 +903,7 @@ where
     TWriter: Read + Seek + ?Sized + Write,
 {
     // Read the font from the input stream
-    let mut font =
-        SfntFont::from_reader(input_stream).map_err(|_| FontError::DeserializationError)?;
+    let mut font = SfntFont::from_reader(input_stream)?;
     // If the C2PA table does not exist...
     if font.tables.get(&C2PA_TABLE_TAG).is_none() {
         // ...install an empty one.
@@ -1089,7 +1088,7 @@ where
 /// table data
 fn read_c2pa_from_stream<T: Read + Seek + ?Sized>(reader: &mut T) -> Result<TableC2PA> {
     // Convert all errors from the reader to a deserialization error.
-    let sfnt = SfntFont::from_reader(reader).map_err(|_| FontError::DeserializationError)?;
+    let sfnt = SfntFont::from_reader(reader)?;
     match sfnt.tables.get(&C2PA_TABLE_TAG) {
         None => Err(FontError::JumbfNotFound),
         // If there is, replace its `manifest_store` value with the

--- a/sdk/src/asset_handlers/woff_io.rs
+++ b/sdk/src/asset_handlers/woff_io.rs
@@ -852,8 +852,7 @@ where
         font.append_empty_c2pa_table()?;
     }
     // Write the font to the output stream
-    font.write(output_stream)
-        .map_err(|_| FontError::SaveError)?;
+    font.write(output_stream)?;
     Ok(())
 }
 
@@ -924,7 +923,7 @@ where
     // Remove the table from the collection
     font.tables.remove(&C2PA_TABLE_TAG);
     // And write it to the destination stream
-    font.write(destination).map_err(|_| FontError::SaveError)?;
+    font.write(destination)?;
 
     Ok(())
 }

--- a/sdk/src/asset_handlers/woff_io.rs
+++ b/sdk/src/asset_handlers/woff_io.rs
@@ -1129,18 +1129,14 @@ impl CAIWriter for WoffIO {
         output_stream: &mut dyn CAIReadWrite,
         store_bytes: &[u8],
     ) -> crate::error::Result<()> {
-        Ok(add_c2pa_to_stream(
-            input_stream,
-            output_stream,
-            store_bytes,
-        )?)
+        add_c2pa_to_stream(input_stream, output_stream, store_bytes).map_err(wrap_font_err)
     }
 
     fn get_object_locations_from_stream(
         &self,
         input_stream: &mut dyn CAIRead,
     ) -> crate::error::Result<Vec<HashObjectPositions>> {
-        Ok(get_object_locations_from_stream(self, input_stream)?)
+        get_object_locations_from_stream(self, input_stream).map_err(wrap_font_err)
     }
 
     fn remove_cai_store_from_stream(
@@ -1148,7 +1144,7 @@ impl CAIWriter for WoffIO {
         input_stream: &mut dyn CAIRead,
         output_stream: &mut dyn CAIReadWrite,
     ) -> crate::error::Result<()> {
-        Ok(remove_c2pa_from_stream(input_stream, output_stream)?)
+        remove_c2pa_from_stream(input_stream, output_stream).map_err(wrap_font_err)
     }
 }
 
@@ -1193,7 +1189,7 @@ impl AssetIO for WoffIO {
     }
 
     fn save_cai_store(&self, asset_path: &Path, store_bytes: &[u8]) -> crate::error::Result<()> {
-        Ok(add_c2pa_to_font(asset_path, store_bytes)?)
+        add_c2pa_to_font(asset_path, store_bytes).map_err(wrap_font_err)
     }
 
     fn get_object_locations(
@@ -1201,11 +1197,11 @@ impl AssetIO for WoffIO {
         asset_path: &Path,
     ) -> crate::error::Result<Vec<HashObjectPositions>> {
         let mut buf_reader = open_bufreader_for_file(asset_path)?;
-        Ok(get_object_locations_from_stream(self, &mut buf_reader)?)
+        get_object_locations_from_stream(self, &mut buf_reader).map_err(wrap_font_err)
     }
 
     fn remove_cai_store(&self, asset_path: &Path) -> crate::error::Result<()> {
-        Ok(remove_c2pa_from_font(asset_path)?)
+        remove_c2pa_from_font(asset_path).map_err(wrap_font_err)
     }
 
     fn asset_box_hash_ref(&self) -> Option<&dyn AssetBoxHash> {
@@ -1246,14 +1242,12 @@ impl RemoteRefEmbed for WoffIO {
             crate::asset_io::RemoteRefEmbedType::Xmp(manifest_uri) => {
                 #[cfg(feature = "xmp_write")]
                 {
-                    Ok(font_xmp_support::add_reference_as_xmp_to_font(
-                        asset_path,
-                        &manifest_uri,
-                    )?)
+                    font_xmp_support::add_reference_as_xmp_to_font(asset_path, &manifest_uri)
+                        .map_err(wrap_font_err)
                 }
                 #[cfg(not(feature = "xmp_write"))]
                 {
-                    Ok(add_reference_to_font(asset_path, &manifest_uri)?)
+                    add_reference_to_font(asset_path, &manifest_uri).map_err(wrap_font_err)
                 }
             }
             crate::asset_io::RemoteRefEmbedType::StegoS(_) => Err(Error::UnsupportedType),
@@ -1272,19 +1266,17 @@ impl RemoteRefEmbed for WoffIO {
             crate::asset_io::RemoteRefEmbedType::Xmp(manifest_uri) => {
                 #[cfg(feature = "xmp_write")]
                 {
-                    Ok(font_xmp_support::add_reference_as_xmp_to_stream(
+                    font_xmp_support::add_reference_as_xmp_to_stream(
                         reader,
                         output_stream,
                         &manifest_uri,
-                    )?)
+                    )
+                    .map_err(wrap_font_err)
                 }
                 #[cfg(not(feature = "xmp_write"))]
                 {
-                    Ok(add_reference_to_stream(
-                        reader,
-                        output_stream,
-                        &manifest_uri,
-                    )?)
+                    add_reference_to_stream(reader, output_stream, &manifest_uri)
+                        .map_err(wrap_font_err)
                 }
             }
             crate::asset_io::RemoteRefEmbedType::StegoS(_) => Err(Error::UnsupportedType),

--- a/sdk/src/asset_handlers/woff_io.rs
+++ b/sdk/src/asset_handlers/woff_io.rs
@@ -31,7 +31,7 @@ use crate::{
         AssetBoxHash, AssetIO, CAIRead, CAIReadWrite, CAIReader, CAIWriter, HashBlockObjectType,
         HashObjectPositions, RemoteRefEmbed, RemoteRefEmbedType,
     },
-    error::{Error, Result},
+    error::Error,
 };
 
 /// This module is a temporary implementation of a very basic support for XMP in
@@ -118,7 +118,7 @@ mod font_xmp_support {
                     .map_err(xmp_write_err)
             }
             // Mention there is no data representing XMP found
-            None => Err(Error::NotFound),
+            None => Err(FontError::XmpNotFound),
         }
     }
 
@@ -127,13 +127,15 @@ mod font_xmp_support {
     /// # Remarks
     /// This is nearly a copy/paste from `embedded_xmp` crate, we should clean this
     /// up at some point
-    fn xmp_write_err(err: XmpError) -> crate::Error {
+    fn xmp_write_err(err: XmpError) -> FontError {
         match err.error_type {
             // convert to OS permission error code so we can detect it correctly upstream
-            XmpErrorType::FilePermission => Error::IoError(std::io::Error::from_raw_os_error(13)),
-            XmpErrorType::NoFile => Error::NotFound,
-            XmpErrorType::NoFileHandler => Error::UnsupportedType,
-            _ => Error::XmpWriteError,
+            XmpErrorType::FilePermission => {
+                FontError::IoError(std::io::Error::from_raw_os_error(13))
+            }
+            XmpErrorType::NoFile => FontError::XmpNoFile(err),
+            XmpErrorType::NoFileHandler => FontError::XmpUnsupportedType(err),
+            _ => FontError::XmpWriteError(err),
         }
     }
 
@@ -178,7 +180,7 @@ mod font_xmp_support {
             Ok(meta) => meta,
             // If data was not found for building out the XMP, we will default
             // to some good starting points
-            Err(Error::NotFound) => default_font_xmp_meta(None, None)?,
+            Err(FontError::XmpNotFound) => default_font_xmp_meta(None, None)?,
             // At this point, the font is considered to be invalid possibly
             Err(error) => return Err(error),
         };
@@ -221,7 +223,7 @@ impl TempFile {
         let path = temp_dir_path.join(
             base_name
                 .file_name()
-                .ok_or_else(|| Error::BadParam("Invalid file name".to_string()))?,
+                .ok_or_else(|| FontError::BadParam("Invalid file name".to_string()))?,
         );
         let file = File::create(&path)?;
         Ok(Self {
@@ -288,9 +290,7 @@ struct WoffFont {
 
 impl WoffFont {
     /// Reads in a WOFF 1 font file from the given stream.
-    fn from_reader<T: Read + Seek + ?Sized>(
-        reader: &mut T,
-    ) -> core::result::Result<WoffFont, Error> {
+    fn from_reader<T: Read + Seek + ?Sized>(reader: &mut T) -> Result<WoffFont> {
         // Read in the WOFFHeader
         let woff_hdr = WoffHeader::from_reader(reader)?;
 
@@ -664,7 +664,7 @@ pub(crate) trait ChunkReader {
 
 /// Reads in chunks for a WOFF 1.0 file
 impl ChunkReader for WoffIO {
-    type Error = crate::error::Error;
+    type Error = FontError;
 
     fn get_chunk_positions<T: Read + Seek + ?Sized>(
         &self,
@@ -763,7 +763,7 @@ where
     TDest: Write + ?Sized,
 {
     source.rewind()?;
-    let mut font = WoffFont::from_reader(source).map_err(|_| FontError::LoadError)?;
+    let mut font = WoffFont::from_reader(source)?;
     // Install the provide active_manifest_uri in this font's C2PA table, adding
     // that table if needed.
     match font.tables.get_mut(&C2PA_TABLE_TAG) {
@@ -777,10 +777,10 @@ where
         Some(NamedTable::C2PA(c2pa)) => c2pa.manifest_store = Some(manifest_store_data.to_vec()),
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
-            return Err(wrap_font_err(FontError::LoadError));
+            return Err(FontError::LoadError);
         }
     };
-    font.write(destination).map_err(|_| FontError::SaveError)?;
+    font.write(destination)?;
     Ok(())
 }
 
@@ -805,7 +805,7 @@ where
     TDest: Write + ?Sized,
 {
     source.rewind()?;
-    let mut font = WoffFont::from_reader(source).map_err(|_| FontError::LoadError)?;
+    let mut font = WoffFont::from_reader(source)?;
     // Install the provide active_manifest_uri in this font's C2PA table, adding
     // that table if needed.
     match font.tables.get_mut(&C2PA_TABLE_TAG) {
@@ -821,10 +821,10 @@ where
         Some(NamedTable::C2PA(c2pa)) => c2pa.active_manifest_uri = Some(manifest_uri.to_string()),
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
-            return Err(wrap_font_err(FontError::LoadError));
+            return Err(FontError::LoadError);
         }
     };
-    font.write(destination).map_err(|_| FontError::SaveError)?;
+    font.write(destination)?;
     Ok(())
 }
 
@@ -894,8 +894,8 @@ where
 {
     match read_c2pa_from_stream(source) {
         Ok(c2pa_data) => Ok(c2pa_data.active_manifest_uri),
-        Err(Error::JumbfNotFound) => Ok(None),
-        Err(_) => Err(wrap_font_err(FontError::DeserializationError)),
+        Err(FontError::JumbfNotFound) => Ok(None),
+        Err(_) => Err(FontError::DeserializationError),
     }
 }
 
@@ -941,7 +941,7 @@ where
     TDest: Write + ?Sized,
 {
     source.rewind()?;
-    let mut font = WoffFont::from_reader(source).map_err(|_| FontError::LoadError)?;
+    let mut font = WoffFont::from_reader(source)?;
     let old_manifest_uri_maybe = match font.tables.get_mut(&C2PA_TABLE_TAG) {
         // If there isn't one, how pleasant, there will be so much less to do.
         None => None,
@@ -959,10 +959,10 @@ where
         }
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
-            return Err(wrap_font_err(FontError::LoadError));
+            return Err(FontError::LoadError);
         }
     };
-    font.write(destination).map_err(|_| FontError::SaveError)?;
+    font.write(destination)?;
     Ok(old_manifest_uri_maybe)
 }
 
@@ -1071,7 +1071,7 @@ where
 /// Reads the `C2PA` font table from the data stream, returning the `C2PA` font
 /// table data
 fn read_c2pa_from_stream<T: Read + Seek + ?Sized>(reader: &mut T) -> Result<TableC2PA> {
-    let woff = WoffFont::from_reader(reader).map_err(|_| FontError::LoadError)?;
+    let woff = WoffFont::from_reader(reader)?;
     let c2pa_table: Option<TableC2PA> = match woff.tables.get(&C2PA_TABLE_TAG) {
         None => None,
         // If there is, replace its `manifest_store` value with the
@@ -1079,10 +1079,10 @@ fn read_c2pa_from_stream<T: Read + Seek + ?Sized>(reader: &mut T) -> Result<Tabl
         Some(NamedTable::C2PA(c2pa)) => Some(c2pa.clone()),
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
-            return Err(wrap_font_err(FontError::LoadError));
+            return Err(FontError::LoadError);
         }
     };
-    c2pa_table.ok_or(Error::JumbfNotFound)
+    c2pa_table.ok_or(FontError::JumbfNotFound)
 }
 
 /// Main WOFF IO feature.
@@ -1102,8 +1102,11 @@ impl WoffIO {
 
 /// WOFF implementation of the CAILoader trait.
 impl CAIReader for WoffIO {
-    fn read_cai(&self, asset_reader: &mut dyn CAIRead) -> Result<Vec<u8>> {
-        let c2pa_table = read_c2pa_from_stream(asset_reader)?;
+    fn read_cai(&self, asset_reader: &mut dyn CAIRead) -> crate::error::Result<Vec<u8>> {
+        let c2pa_table = read_c2pa_from_stream(asset_reader).map_err(|e| match e {
+            FontError::JumbfNotFound => Error::JumbfNotFound,
+            _ => wrap_font_err(e),
+        })?;
         match c2pa_table.get_manifest_store() {
             Some(manifest_store) => Ok(manifest_store.to_vec()),
             _ => Err(Error::JumbfNotFound),
@@ -1127,23 +1130,27 @@ impl CAIWriter for WoffIO {
         input_stream: &mut dyn CAIRead,
         output_stream: &mut dyn CAIReadWrite,
         store_bytes: &[u8],
-    ) -> Result<()> {
-        add_c2pa_to_stream(input_stream, output_stream, store_bytes)
+    ) -> crate::error::Result<()> {
+        Ok(add_c2pa_to_stream(
+            input_stream,
+            output_stream,
+            store_bytes,
+        )?)
     }
 
     fn get_object_locations_from_stream(
         &self,
         input_stream: &mut dyn CAIRead,
-    ) -> Result<Vec<HashObjectPositions>> {
-        get_object_locations_from_stream(self, input_stream)
+    ) -> crate::error::Result<Vec<HashObjectPositions>> {
+        Ok(get_object_locations_from_stream(self, input_stream)?)
     }
 
     fn remove_cai_store_from_stream(
         &self,
         input_stream: &mut dyn CAIRead,
         output_stream: &mut dyn CAIReadWrite,
-    ) -> Result<()> {
-        remove_c2pa_from_stream(input_stream, output_stream)
+    ) -> crate::error::Result<()> {
+        Ok(remove_c2pa_from_stream(input_stream, output_stream)?)
     }
 }
 
@@ -1182,22 +1189,25 @@ impl AssetIO for WoffIO {
         ]
     }
 
-    fn read_cai_store(&self, asset_path: &Path) -> Result<Vec<u8>> {
+    fn read_cai_store(&self, asset_path: &Path) -> crate::error::Result<Vec<u8>> {
         let mut f: File = File::open(asset_path)?;
         self.read_cai(&mut f)
     }
 
-    fn save_cai_store(&self, asset_path: &Path, store_bytes: &[u8]) -> Result<()> {
-        add_c2pa_to_font(asset_path, store_bytes)
+    fn save_cai_store(&self, asset_path: &Path, store_bytes: &[u8]) -> crate::error::Result<()> {
+        Ok(add_c2pa_to_font(asset_path, store_bytes)?)
     }
 
-    fn get_object_locations(&self, asset_path: &Path) -> Result<Vec<HashObjectPositions>> {
+    fn get_object_locations(
+        &self,
+        asset_path: &Path,
+    ) -> crate::error::Result<Vec<HashObjectPositions>> {
         let mut buf_reader = open_bufreader_for_file(asset_path)?;
-        get_object_locations_from_stream(self, &mut buf_reader)
+        Ok(get_object_locations_from_stream(self, &mut buf_reader)?)
     }
 
-    fn remove_cai_store(&self, asset_path: &Path) -> Result<()> {
-        remove_c2pa_from_font(asset_path)
+    fn remove_cai_store(&self, asset_path: &Path) -> crate::error::Result<()> {
+        Ok(remove_c2pa_from_font(asset_path)?)
     }
 
     fn asset_box_hash_ref(&self) -> Option<&dyn AssetBoxHash> {
@@ -1207,7 +1217,7 @@ impl AssetIO for WoffIO {
 
 // Implementation for the asset box hash trait for general box hash support
 impl AssetBoxHash for WoffIO {
-    fn get_box_map(&self, input_stream: &mut dyn CAIRead) -> Result<Vec<BoxMap>> {
+    fn get_box_map(&self, input_stream: &mut dyn CAIRead) -> crate::error::Result<Vec<BoxMap>> {
         // Get the chunk positions
         let positions = self.get_chunk_positions(input_stream)?;
         // Create a box map vector to map the chunk positions to
@@ -1233,16 +1243,19 @@ impl RemoteRefEmbed for WoffIO {
         &self,
         asset_path: &Path,
         embed_ref: crate::asset_io::RemoteRefEmbedType,
-    ) -> Result<()> {
+    ) -> crate::error::Result<()> {
         match embed_ref {
             crate::asset_io::RemoteRefEmbedType::Xmp(manifest_uri) => {
                 #[cfg(feature = "xmp_write")]
                 {
-                    font_xmp_support::add_reference_as_xmp_to_font(asset_path, &manifest_uri)
+                    Ok(font_xmp_support::add_reference_as_xmp_to_font(
+                        asset_path,
+                        &manifest_uri,
+                    )?)
                 }
                 #[cfg(not(feature = "xmp_write"))]
                 {
-                    add_reference_to_font(asset_path, &manifest_uri)
+                    Ok(add_reference_to_font(asset_path, &manifest_uri)?)
                 }
             }
             crate::asset_io::RemoteRefEmbedType::StegoS(_) => Err(Error::UnsupportedType),
@@ -1256,20 +1269,24 @@ impl RemoteRefEmbed for WoffIO {
         reader: &mut dyn CAIRead,
         output_stream: &mut dyn CAIReadWrite,
         embed_ref: RemoteRefEmbedType,
-    ) -> Result<()> {
+    ) -> crate::error::Result<()> {
         match embed_ref {
             crate::asset_io::RemoteRefEmbedType::Xmp(manifest_uri) => {
                 #[cfg(feature = "xmp_write")]
                 {
-                    font_xmp_support::add_reference_as_xmp_to_stream(
+                    Ok(font_xmp_support::add_reference_as_xmp_to_stream(
                         reader,
                         output_stream,
                         &manifest_uri,
-                    )
+                    )?)
                 }
                 #[cfg(not(feature = "xmp_write"))]
                 {
-                    add_reference_to_stream(reader, output_stream, &manifest_uri)
+                    Ok(add_reference_to_stream(
+                        reader,
+                        output_stream,
+                        &manifest_uri,
+                    )?)
                 }
             }
             crate::asset_io::RemoteRefEmbedType::StegoS(_) => Err(Error::UnsupportedType),
@@ -1639,10 +1656,12 @@ pub mod tests {
         use xmp_toolkit::XmpMeta;
 
         use crate::{
-            asset_handlers::woff_io::{font_xmp_support, WoffIO},
+            asset_handlers::{
+                font_io::FontError,
+                woff_io::{font_xmp_support, WoffIO},
+            },
             asset_io::CAIReader,
             utils::test::temp_dir_path,
-            Error,
         };
 
         #[ignore] // Need WOFF 1 test fixture
@@ -1718,7 +1737,7 @@ pub mod tests {
             let mut font_stream: Cursor<&[u8]> = Cursor::<&[u8]>::new(&font_data);
             match font_xmp_support::build_xmp_from_stream(&mut font_stream) {
                 Ok(_) => panic!("Did not expect an OK result, as data is missing"),
-                Err(Error::NotFound) => {}
+                Err(FontError::XmpNotFound) => {}
                 Err(_) => panic!("Unexpected error when building XMP data"),
             }
         }

--- a/sdk/src/asset_handlers/woff_io.rs
+++ b/sdk/src/asset_handlers/woff_io.rs
@@ -844,7 +844,8 @@ where
     TWriter: Read + Seek + ?Sized + Write,
 {
     // Read the font from the input stream
-    let mut font = WoffFont::from_reader(input_stream).map_err(|_| FontError::DeserializationError)?;
+    let mut font =
+        WoffFont::from_reader(input_stream).map_err(|_| FontError::DeserializationError)?;
     // If the C2PA table does not exist...
     if font.tables.get(&C2PA_TABLE_TAG).is_none() {
         // ...install an empty one.

--- a/sdk/src/asset_handlers/woff_io.rs
+++ b/sdk/src/asset_handlers/woff_io.rs
@@ -844,8 +844,7 @@ where
     TWriter: Read + Seek + ?Sized + Write,
 {
     // Read the font from the input stream
-    let mut font =
-        WoffFont::from_reader(input_stream).map_err(|_| FontError::DeserializationError)?;
+    let mut font = WoffFont::from_reader(input_stream)?;
     // If the C2PA table does not exist...
     if font.tables.get(&C2PA_TABLE_TAG).is_none() {
         // ...install an empty one.
@@ -919,7 +918,7 @@ where
 {
     source.rewind()?;
     // Load the font from the stream
-    let mut font = WoffFont::from_reader(source).map_err(|_| FontError::DeserializationError)?;
+    let mut font = WoffFont::from_reader(source)?;
     // Remove the table from the collection
     font.tables.remove(&C2PA_TABLE_TAG);
     // And write it to the destination stream
@@ -1072,7 +1071,7 @@ where
 /// table data
 fn read_c2pa_from_stream<T: Read + Seek + ?Sized>(reader: &mut T) -> Result<TableC2PA> {
     // Convert all errors from the reader to a deserialization error.
-    let woff = WoffFont::from_reader(reader).map_err(|_| FontError::DeserializationError)?;
+    let woff = WoffFont::from_reader(reader)?;
     match woff.tables.get(&C2PA_TABLE_TAG) {
         None => Err(FontError::JumbfNotFound),
         // If there is, replace its `manifest_store` value with the


### PR DESCRIPTION
## Changes in this pull request

An extension to the previous PR which now converts all internal font_io/sft_io/woff_io calls to use `FontError` as the error type. And then all of the crate level trait implementations, the error is converted to a `crate::error::Error`.

I also took the time to delete unused errors and split errors that were being used generically into more detailed errors.

For the `SaveError` I spun out a separate error enum to scope the errors for more details on the save errors.

## Checklist
- [X] This PR represents a single feature, fix, or change.
- [X] All applicable changes have been documented.
