### PR TITLE
C2PA-303: Harden SfntIO test matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@ Cargo.lock
 **/*.rs.bk
 
 .DS_Store
+.coverage
 .idea
-
 .vscode
 
 /semver-checks/target/

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@ Cargo.lock
 **/*.rs.bk
 
 .DS_Store
-.coverage
 .idea
+
 .vscode
 
 /semver-checks/target/

--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -850,19 +850,43 @@ pub mod tests {
 
     use super::*;
 
-    // Test SfntTag Debug & Display trait support.
+    // Test FontError Debug trait.
     #[test]
-    fn sfnt_tag_debug_n_display_impls() {
+    fn font_error_debug_and_display_impls() {
+        let ferr = FontError::InvalidNamedTable("SPLuK");
+        let ferr_debug = format!("{:#?}", ferr);
+        assert_eq!(ferr_debug, "InvalidNamedTable(\n    \"SPLuK\",\n)");
+        let ferr_display = format!("{}", ferr);
+        assert_eq!(ferr_display, "Invalid named table: SPLuK");
+    }
+
+    // Test FontSaveError Debug trait.
+    #[test]
+    fn font_save_error_debug_and_display_impls() {
+        let fserr = FontSaveError::UnexpectedTable("KlerF".to_string());
+        let fserr_debug = format!("{:#?}", fserr);
+        assert_eq!(fserr_debug, "UnexpectedTable(\n    \"KlerF\",\n)");
+        let fserr_display = format!("{}", fserr);
+        assert_eq!(
+            fserr_display,
+            "Unexpected table found in the table directory: KlerF"
+        );
+    }
+
+    // Test SfntTag Debug & Display trait.
+    #[test]
+    fn sfnt_tag_debug_and_display_impls() {
         // Softball
         let garf_tag = {
             SfntTag {
                 data: [0x47_u8, 0x61_u8, 0x52_u8, 0x66_u8],
             }
         };
-        let garf_tag_display = format!("{}", garf_tag);
-        assert_eq!(garf_tag_display, "GaRf");
         let garf_tag_debug = format!("{:#?}", garf_tag);
         assert_eq!(garf_tag_debug, "GaRf");
+
+        let garf_tag_display = format!("{}", garf_tag);
+        assert_eq!(garf_tag_display, "GaRf");
 
         // Some cruddy values
         let nul_vt_del_us_tag = {
@@ -871,14 +895,14 @@ pub mod tests {
             }
         };
         let nul_vt_del_us_tag_expected = [0_u8, 0x11_u8, 0xef_u8, 0xbf_u8, 0xbd_u8, 0x1f_u8];
-        let nul_vt_del_us_tag_display = format!("{}", nul_vt_del_us_tag);
-        assert_eq!(
-            nul_vt_del_us_tag_display.as_bytes(),
-            nul_vt_del_us_tag_expected
-        );
         let nul_vt_del_us_tag_debug = format!("{:#?}", nul_vt_del_us_tag);
         assert_eq!(
             nul_vt_del_us_tag_debug.as_bytes(),
+            nul_vt_del_us_tag_expected
+        );
+        let nul_vt_del_us_tag_display = format!("{}", nul_vt_del_us_tag);
+        assert_eq!(
+            nul_vt_del_us_tag_display.as_bytes(),
             nul_vt_del_us_tag_expected
         );
     }

--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -192,6 +192,7 @@ pub(crate) fn align_to_four(size: usize) -> usize {
 /// Note that Embedded OpenType and MicroType Express formats cannot be detected
 /// with a simple magic-number sniff. Conceivably, EOT could be dealt with as a
 /// variation on SFNT, but MTX will needs more exotic handling.
+#[derive(PartialEq)]
 pub(crate) enum Magic {
     /// 'OTTO' - OpenType
     OpenType = 0x4f54544f,

--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -845,6 +845,7 @@ pub(crate) struct SfntDirectoryEntry {
 
 #[cfg(test)]
 pub mod tests {
+    #![allow(clippy::panic)]
     #![allow(clippy::unwrap_used)]
 
     use std::io::Cursor;

--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -636,6 +636,7 @@ impl TableHead {
             Err(FontError::LoadHeadTableTruncated)
         } else {
             let head = Self {
+                // TBD - domain-map any read errors into "truncated table"
                 // 0x00
                 majorVersion: reader.read_u16::<BigEndian>()?,
                 minorVersion: reader.read_u16::<BigEndian>()?,

--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -800,6 +800,11 @@ impl TableUnspecified {
 }
 
 impl Table for TableUnspecified {
+    /// NOTE - We _should_ be able to prune out `checksum` and `len`, because
+    /// we only need them for C2PA; but it leads to a wrinkle in sfnt_io,
+    /// inside the write function, which wants to call Table.checksum() and
+    /// Table.len(), but which will need to learn to down-cast to TableC2PA and
+    /// invoke the functions  directly.
     fn checksum(&self) -> Wrapping<u32> {
         checksum(&self.data)
     }

--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -171,7 +171,7 @@ impl std::fmt::Debug for SfntTag {
 /// Round the given value up to the next multiple of four (4).
 ///
 /// # Examples
-/// ```
+/// ```ignore // Because asset_handlers is private...
 /// let thirty_six_or_forty = (
 ///     c2pa::asset_handlers::font_io::align_to_four(36),
 ///     c2pa::asset_handlers::font_io::align_to_four(38),
@@ -331,7 +331,7 @@ pub(crate) fn checksum_biased(bytes: &[u8], bias: u32) -> Wrapping<u32> {
 /// more-significant position.
 ///
 /// # Examples
-/// ```
+/// ```ignore // Because asset_handlers is private...
 /// let full_word = c2pa::asset_handlers::font_io::u32_from_u16_pair(0x1234, 0x5678);
 /// assert_eq!(full_word, std::num::Wrapping(0x12345678));
 /// ```

--- a/sdk/src/asset_handlers/sfnt_io.rs
+++ b/sdk/src/asset_handlers/sfnt_io.rs
@@ -1817,10 +1817,7 @@ pub mod tests {
             // Verify the reference was removed
             {
                 let mut f: File = File::open(&output).unwrap();
-                match otf_handler.read_xmp(&mut f) {
-                    Some(xmp_data_str) => panic!("Unexpected XMP data: {}", xmp_data_str),
-                    None => (),
-                }
+                assert_none!(otf_handler.read_xmp(&mut f));
             }
         }
 

--- a/sdk/src/asset_handlers/sfnt_io.rs
+++ b/sdk/src/asset_handlers/sfnt_io.rs
@@ -1470,13 +1470,14 @@ pub mod tests {
         // Create our SfntIO asset handler for testing
         let sfnt_io = SfntIO {};
 
-        // The font has 11 records, 11 tables, 1 table directory
-        // but the head table will expand from 1 to 3 positions bringing it to 25
-        // And then the required C2PA chunks will be added, bringing it to 27
-        let saved_log_level = log::max_level();
-        log::set_max_level(log::LevelFilter::Trace);
+        // We expect 15 "objects"
+        // 0. The "header" (file header + table directory), as "Cai"
+        // 1. The first 8 bytes of the `head` table, as "Other"
+        // 2. The 4-byte checksumAdjustment field, as "Cai"
+        // 3. The rest of the `head` table.
+        // 4-13. The other tables in the font.
+        // 14. The C2PA table, automatically added when the font is deserialized
         let positions = sfnt_io.get_object_locations(&output).unwrap();
-        log::set_max_level(saved_log_level);
         assert_eq!(15, positions.len());
     }
 
@@ -1495,10 +1496,19 @@ pub mod tests {
         // Create our SfntIO asset handler for testing
         let sfnt_io = SfntIO {};
 
-        // The font has 11 records, 11 tables, 1 table directory
-        // but the head table will expand from 1 to 3 positions bringing it to 25
-        // And then the required C2PA chunks will be added, bringing it to 27
+        // We expect 15 "objects"
+        // 0. The "header" (file header + table directory), as "Cai"
+        // 1. The first 8 bytes of the `head` table, as "Other"
+        // 2. The 4-byte checksumAdjustment field, as "Cai"
+        // 3. The rest of the `head` table.
+        // 4-13. The other tables in the font.
+        // 14. The C2PA table, which was already present in this file.
+        //
+        // Note that we also flip on Trace logging, to test those paths.
+        let saved_log_level = log::max_level();
+        log::set_max_level(log::LevelFilter::Trace);
         let positions = sfnt_io.get_object_locations(&output).unwrap();
+        log::set_max_level(saved_log_level);
         assert_eq!(15, positions.len());
     }
 

--- a/sdk/src/asset_handlers/sfnt_io.rs
+++ b/sdk/src/asset_handlers/sfnt_io.rs
@@ -1913,12 +1913,13 @@ pub mod tests {
     #[cfg(feature = "xmp_write")]
     #[cfg(test)]
     pub mod font_xmp_support_tests {
-        use std::{fs::File, io::Cursor, str::FromStr};
+        use std::{fs::File, io::Cursor, path::Path, str::FromStr};
 
         use claims::*;
         use tempfile::tempdir;
         use xmp_toolkit::XmpMeta;
 
+        use super::{process_file_with_streams, remove_reference_from_stream};
         use crate::{
             asset_handlers::{
                 font_io::FontError,
@@ -1931,10 +1932,9 @@ pub mod tests {
         /// Remove any remote manifest reference from any `C2PA` font table which
         /// exists in the given font file (specified by path).
         #[allow(dead_code)]
-        fn remove_reference_from_font(font_path: &Path) -> Result<()> {
-            let sfnt_io = SfntIO {};
-            sfnt_io.process_file_with_streams(font_path, move |input_stream, temp_file| {
-                sfnt_io.remove_reference_from_stream(input_stream, temp_file.get_mut_file())?;
+        fn remove_reference_from_font(font_path: &Path) -> Result<(), FontError> {
+            process_file_with_streams(font_path, move |input_stream, temp_file| {
+                remove_reference_from_stream(input_stream, temp_file.get_mut_file())?;
                 Ok(())
             })
         }

--- a/sdk/src/asset_handlers/sfnt_io.rs
+++ b/sdk/src/asset_handlers/sfnt_io.rs
@@ -565,17 +565,6 @@ impl SfntDirectoryEntry {
     }
 }
 
-impl Default for SfntDirectoryEntry {
-    fn default() -> Self {
-        Self {
-            tag: SfntTag::new(*b"\0\0\0\0"),
-            checksum: 0,
-            offset: 0,
-            length: 0,
-        }
-    }
-}
-
 /// SFNT Directory is just an array of entries. Undoubtedly there exists a
 /// more-oxidized way of just using Vec directly for this... but maybe we
 /// don't want to? Note the choice of Vec over BTreeMap here, which lets us


### PR DESCRIPTION
## Changes in this pull request

Adds unit & integration tests to increase coverage, and hardens some routines in response.

The [associated JIRA issue](https://monotype.atlassian.net/browse/C2PA-303) includes ZIP files of code-coverage reports for the epic branch, and for this topic branch. Refer to [Confluence](https://monotype.atlassian.net/wiki/spaces/EN/pages/4836589606/Rust+Coverage) to generate your own coverage reports.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
