### PR TITLE
C2PA-312: Not using fonttools, so no need to ignore its problems.

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -24,10 +24,6 @@ ignore = [
   "RUSTSEC-2021-0146", # twoway (see https://github.com/contentauth/c2pa-rs/issues/234)
   "RUSTSEC-2022-0081", # json (see https://github.com/contentauth/c2pa-rs/issues/318)
   "RUSTSEC-2023-0071", # rsa Marvin Attack: (https://jira.corp.adobe.com/browse/CAI-5104)
-  "RUSTSEC-2021-0145", # Dependency on atty via fontools, will eventually go away
-                       # (see https://monotype.atlassian.net/browse/C2PA-280)
-  "RUSTSEC-2021-0153", # Dependency on encoding via fontools, will eventually go away
-                       # (see https://monotype.atlassian.net/browse/C2PA-280)
 ]
 
 # Deny multiple versions unless explicitly skipped.


### PR DESCRIPTION
## Changes in this pull request
We had added two ignore-rules in order to let (downstream dependencies of) `fonttools` build; but as we no longer depend on that crate, we no longer need the rules.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
