### PR TITLE
C2PA-328: Box hashing support

### DIFF
--- a/sdk/src/assertions/box_hash.rs
+++ b/sdk/src/assertions/box_hash.rs
@@ -332,6 +332,31 @@ mod tests {
             .unwrap();
     }
 
+    #[cfg(feature = "sfnt")]
+    #[test]
+    fn test_hash_verify_signed_sfnt() {
+        // Similar to the test_hash_verify_sfnt test, but with a signed font file
+        // to verify dealing with the `C2PA` box.
+        let ap = fixture_path("font_c2pa.otf");
+
+        let bhp = get_assetio_handler_from_path(&ap)
+            .unwrap()
+            .asset_box_hash_ref()
+            .unwrap();
+
+        let mut input = File::open(&ap).unwrap();
+
+        let mut bh = BoxHash { boxes: Vec::new() };
+
+        // generate box hashes
+        bh.generate_box_hash_from_stream(&mut input, "sha256", bhp, false)
+            .unwrap();
+
+        // see if they match reading
+        bh.verify_stream_hash(&mut input, Some("sha256"), bhp)
+            .unwrap();
+    }
+
     #[test]
     fn test_hash_verify_jpg() {
         let ap = fixture_path("CA.jpg");

--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -72,6 +72,10 @@ pub enum FontError {
     #[error("Invalid or unsupported font format")]
     Unsupported,
 
+    /// Failed to convert a byte array to a string as UTF-8.
+    #[error(transparent)]
+    Utf8Error(#[from] std::str::Utf8Error),
+
     /// XMP data was not found.
     #[cfg(feature = "xmp_write")]
     #[error("XMP data was not found in the font.")]

--- a/sdk/src/asset_handlers/sfnt_io.rs
+++ b/sdk/src/asset_handlers/sfnt_io.rs
@@ -1403,6 +1403,29 @@ pub mod tests {
     }
 
     #[test]
+    fn chunk_name_as_string() {
+        let chunk = ChunkPosition {
+            offset: 0,
+            length: 0,
+            name: [65, 66, 67, 68],
+            chunk_type: ChunkType::Header,
+        };
+        assert_eq!(chunk.name_as_string().unwrap(), "ABCD");
+    }
+
+    #[test]
+    fn chunk_name_as_string_with_invalid_utf8() {
+        let chunk = ChunkPosition {
+            offset: 0,
+            length: 0,
+            // Use an invalid UTF-8 sequence to cause an error
+            name: [b'\xE0', b'\x80', b'\x80', b'\0'],
+            chunk_type: ChunkType::Header,
+        };
+        assert_err!(chunk.name_as_string());
+    }
+
+    #[test]
     fn chunk_position_debug_and_display() {
         let chunk = ChunkPosition {
             offset: 72,


### PR DESCRIPTION
## Changes in this pull request
_Give a narrative description of what has been changed._

Actually, implements the generation of the hash for the general box hash for sfnt.

According to https://github.com/Monotype/c2pa-rs/blob/main/sdk/src/asset_io.rs#L225, the implementations of `AssetBoxHash::get_box_map` does not need to calculate the hash. It looks like the `BoxHash::generate_box_hash_from_stream` does the calculation and the `Boxhash::verify_stream_hash`  does the verification.

With that said, this change does stick to the [specification](https://c2pa.org/specifications/specifications/2.0/specs/C2PA_Specification.html#_font_specific_handling).


