### PR TITLE
C2PA-353: Add chunked transfer encoding to workaround VPN issue

### DIFF
--- a/sdk/src/time_stamp.rs
+++ b/sdk/src/time_stamp.rs
@@ -128,6 +128,13 @@ fn time_stamp_request_http(
 
     let response = req
         .set("Content-Type", HTTP_CONTENT_TYPE_REQUEST)
+        // Temporary workaround:
+        // Currently there exists a problem with the some VPN servers where this
+        // request to timestamp fails if being sent to
+        // http://timestamp.digicert.com; we don't know exactly why this is,
+        // it's possibly a VPN configuration issue.  Until then, adding this
+        // line appears to circumvent the issue.  (C2PA-381)
+        .set("Transfer-Encoding", "chunked")
         .send(body_reader)
         .map_err(|_err| Error::CoseTimeStampGeneration)?;
 


### PR DESCRIPTION
## Changes in this pull request

This is a monotype-specific workaround which allows us to utilize certain timestamp servers (notably http://timestamp.digicert.com) over some of our VPN connections. This should be taken out once the VPN configuration issue is solved.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
