### PR TITLE
Merge main in (hitting issue with unmaintained yaml-rust crate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project adheres to [Semantic Versioning](https://semver.org), except that â
 
 Do not manually edit this file. It will be automatically updated when a new release is published.
 
+## 0.31.1
+_25 March 2024_
+
+* Adds Action changes field as option vec of serde_json value ([#431](https://github.com/contentauth/c2pa-rs/pull/431))
+
 ## 0.31.0
 _13 March 2024_
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-c2pa = "0.31.0"
+c2pa = "0.31.1"
 ```
 
 If you want to read or write a manifest file, add the `file_io` dependency to your `Cargo.toml`.

--- a/export_schema/Cargo.toml
+++ b/export_schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "export_schema"
-version = "0.31.0"
+version = "0.31.1"
 authors = ["Dave Kozma <dkozma@adobe.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "make_test_images"
-version = "0.31.0"
+version = "0.31.1"
 authors = ["Gavin Peacock <gpeacock@adobe.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -71,7 +71,7 @@ chrono = { version = "0.4.27", default-features = false, features = [
 	"wasmbind",
 ] }
 ciborium = "0.2.0"
-config = "0.14.0"
+config = {version = "0.14.0", default-features = false, features = ["json", "json5", "toml", "ron", "ini"]}
 conv = "0.3.3"
 coset = "0.3.1"
 extfmt = "0.1.1"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa"
-version = "0.31.0"
+version = "0.31.1"
 description = "Rust SDK for C2PA (Coalition for Content Provenance and Authenticity) implementors"
 authors = [
 	"Maurice Fisher <mfisher@adobe.com>",

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -639,7 +639,13 @@ impl Manifest {
                 _ => {
                     // inject assertions for all other assertions
                     match assertion.decode_data() {
-                        AssertionData::Json(_) | AssertionData::Cbor(_) => {
+                        AssertionData::Cbor(_) => {
+                            let value = assertion.as_json_object()?;
+                            let ma = ManifestAssertion::new(base_label, value)
+                                .set_instance(claim_assertion.instance());
+                            manifest.assertions.push(ma);
+                        }
+                        AssertionData::Json(_) => {
                             let value = assertion.as_json_object()?;
                             let ma = ManifestAssertion::new(base_label, value)
                                 .set_instance(claim_assertion.instance())
@@ -1424,6 +1430,68 @@ pub(crate) mod tests {
     }
 
     #[test]
+    #[cfg(feature = "file_io")]
+    /// test assertion validation on actions, should generate an error
+    fn ws_valid_labeled_assertion() {
+        // copy an image to use as our target for embedding
+        let ap = fixture_path(TEST_SMALL_JPEG);
+        let temp_dir = tempdir().expect("temp dir");
+        let test_output = temp_dir_path(&temp_dir, "ws_bad_assertion.jpg");
+        std::fs::copy(ap, test_output).expect("copy");
+
+        let mut manifest = test_manifest();
+
+        manifest
+            .add_labeled_assertion(
+                "c2pa.actions",
+                &serde_json::json!({
+                    "actions": [
+                        {
+                            "action": "c2pa.edited",
+                            "parameters": {
+                                "description": "gradient",
+                                "name": "any value"
+                            },
+                            "softwareAgent": "TestApp"
+                        },
+                        {
+                            "action": "c2pa.dubbed",
+                            "changes": [
+                                {
+                                    "description": "translated to klingon",
+                                    "region": [
+                                        {
+                                            "type": "temporal",
+                                            "time": {}
+                                        },
+                                        {
+                                            "type": "identified",
+                                            "item": {
+                                                "identifier": "https://bioportal.bioontology.org/ontologies/FMA",
+                                                "value": "lips"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }),
+            )
+            .expect("add_assertion");
+
+        // convert to store
+        let store = manifest.to_store().expect("valid action to_store");
+        let m2 = Manifest::from_store(&store, &store.provenance_label().unwrap(), None)
+            .expect("from_store");
+        let actions: Actions = m2
+            .find_assertion("c2pa.actions.v2")
+            .expect("find_assertion");
+        assert_eq!(actions.actions()[0].action(), "c2pa.edited");
+        assert_eq!(actions.actions()[1].action(), "c2pa.dubbed");
+    }
+
+    #[test]
     fn test_verifiable_credential() {
         let mut manifest = test_manifest();
         let vc: serde_json::Value = serde_json::from_str(TEST_VC).unwrap();
@@ -1974,7 +2042,25 @@ pub(crate) mod tests {
                                     "identifier": "sample1.svg"
                                 },
                                 "something": "else"
-                            }
+                            },
+                            "changes": [
+                                {
+                                    "region" : [
+                                        {
+                                            "type" : "temporal",
+                                            "time" : {}
+                                        },
+                                        {
+                                            "type" : "identified",
+                                            "item" : {
+                                              "identifier" : "https://bioportal.bioontology.org/ontologies/FMA",
+                                              "value" : "lips"
+                                            }
+                                        }
+                                    ],
+                                    "description": "lip synced area"
+                                }
+                            ]
                         }
                     ],
                     "templates": [

--- a/sdk/src/settings.rs
+++ b/sdk/src/settings.rs
@@ -222,7 +222,7 @@ impl Settings {
             "json5" => FileFormat::Json5,
             "ini" => FileFormat::Ini,
             "toml" => FileFormat::Toml,
-            "yaml" => FileFormat::Yaml,
+            //"yaml" => FileFormat::Yaml,
             "ron" => FileFormat::Ron,
             _ => return Err(Error::UnsupportedType),
         };


### PR DESCRIPTION
## Changes in this pull request

Merging `main` branch into our `monotype/fontSupport` branch to pick up changes, mainly the removal `config` features which utilized the unmaintained `yaml-rust` crate.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
