### PR TITLE
C2PA-484: Replace existing DSIG with dummy DSIG after signing

### DIFF
--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -600,7 +600,7 @@ impl Default for TableC2PA {
 
 /// 'head' font table. For now, there is no need for a 'raw' variant, since only
 /// byte-swapping is needed.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[repr(C, packed(1))]
 // As defined by Open Font Format / OpenType (though we don't as yet directly
 // support exotics like FIXED).

--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -600,7 +600,7 @@ impl Default for TableC2PA {
 
 /// 'head' font table. For now, there is no need for a 'raw' variant, since only
 /// byte-swapping is needed.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[repr(C, packed(1))]
 // As defined by Open Font Format / OpenType (though we don't as yet directly
 // support exotics like FIXED).
@@ -739,14 +739,29 @@ impl Table for TableHead {
     }
 
     fn checksum(&self) -> Wrapping<u32> {
+        let mut modified_head = self.clone();
+        modified_head.checksumAdjustment = 0;
+
         // Write to a temporary buffer.
         let mut buffer: Vec<u8> = Vec::with_capacity(size_of::<Self>());
         // TODO: This could fail -- how do we want to handle that?  We could
         // return a result.. but in doing so we can't call this from the closure
         // of the foreach anymore (because it can't return a result)...
-        self.write(&mut buffer).unwrap();
+        modified_head.write(&mut buffer).unwrap();
         // Compute the checksum.
         checksum(&buffer)
+
+        /*
+        let mut cksum = u32_from_u16_pair(self.majorVersion, self.minorVersion);
+        cksum += self.fontRevision;
+        // Skip checksum adjustment (calculated as zero)
+        cksum += self.magicNumber;
+        cksum += u32_from_u16_pair(self.flags, self.unitsPerEm);
+        chsum += u32_
+
+        cksum += self.manifestStoreOffset + self.manifestStoreLength;
+        cksum
+        */
     }
 }
 

--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -875,11 +875,11 @@ impl Table for TableUnspecified {
 /// Possible tables
 pub(crate) enum NamedTable {
     /// 'C2PA' table
-    C2PA(TableC2PA),
+    C2pa(TableC2PA),
     /// 'head' table
     Head(TableHead),
     /// 'DSIG' table,
-    DSIG(TableDSIG),
+    Dsig(TableDSIG),
     /// any other table
     Unspecified(TableUnspecified),
 }
@@ -894,13 +894,13 @@ impl NamedTable {
         length: usize,
     ) -> Result<Self> {
         match *tag {
-            C2PA_TABLE_TAG => Ok(NamedTable::C2PA(TableC2PA::from_reader(
+            C2PA_TABLE_TAG => Ok(NamedTable::C2pa(TableC2PA::from_reader(
                 reader, offset, length,
             )?)),
             HEAD_TABLE_TAG => Ok(NamedTable::Head(TableHead::from_reader(
                 reader, offset, length,
             )?)),
-            DSIG_TABLE_TAG => Ok(NamedTable::DSIG(TableDSIG::from_reader(
+            DSIG_TABLE_TAG => Ok(NamedTable::Dsig(TableDSIG::from_reader(
                 reader, offset, length,
             )?)),
             _ => Ok(NamedTable::Unspecified(TableUnspecified::from_reader(
@@ -913,27 +913,27 @@ impl NamedTable {
 impl Table for NamedTable {
     fn write<TDest: Write + ?Sized>(&self, destination: &mut TDest) -> Result<()> {
         match self {
-            NamedTable::C2PA(c2pa) => c2pa.write(destination),
+            NamedTable::C2pa(c2pa) => c2pa.write(destination),
             NamedTable::Head(head) => head.write(destination),
-            NamedTable::DSIG(dsig) => dsig.write(destination),
+            NamedTable::Dsig(dsig) => dsig.write(destination),
             NamedTable::Unspecified(un) => un.write(destination),
         }
     }
 
     fn len(&self) -> u32 {
         match self {
-            NamedTable::C2PA(c2pa) => c2pa.len(),
+            NamedTable::C2pa(c2pa) => c2pa.len(),
             NamedTable::Head(head) => head.len(),
-            NamedTable::DSIG(dsig) => dsig.len(),
+            NamedTable::Dsig(dsig) => dsig.len(),
             NamedTable::Unspecified(un) => un.len(),
         }
     }
 
     fn checksum(&self) -> Wrapping<u32> {
         match self {
-            NamedTable::C2PA(c2pa) => c2pa.checksum(),
+            NamedTable::C2pa(c2pa) => c2pa.checksum(),
             NamedTable::Head(head) => head.checksum(),
-            NamedTable::DSIG(dsig) => dsig.checksum(),
+            NamedTable::Dsig(dsig) => dsig.checksum(),
             NamedTable::Unspecified(un) => un.checksum(),
         }
     }

--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -553,14 +553,14 @@ impl Table for TableC2PA {
 
     fn len(&self) -> u32 {
         let length = size_of::<TableC2PARaw>()
-        + match &self.active_manifest_uri {
-            Some(uri) => uri.len(),
-            None => 0,
-        }
-        + match &self.manifest_store {
-            Some(store) => store.len(),
-            None => 0,
-        };
+            + match &self.active_manifest_uri {
+                Some(uri) => uri.len(),
+                None => 0,
+            }
+            + match &self.manifest_store {
+                Some(store) => store.len(),
+                None => 0,
+            };
 
         length as u32
     }

--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -739,29 +739,27 @@ impl Table for TableHead {
     }
 
     fn checksum(&self) -> Wrapping<u32> {
-        let mut modified_head = self.clone();
-        modified_head.checksumAdjustment = 0;
-
-        // Write to a temporary buffer.
-        let mut buffer: Vec<u8> = Vec::with_capacity(size_of::<Self>());
-        // TODO: This could fail -- how do we want to handle that?  We could
-        // return a result.. but in doing so we can't call this from the closure
-        // of the foreach anymore (because it can't return a result)...
-        modified_head.write(&mut buffer).unwrap();
-        // Compute the checksum.
-        checksum(&buffer)
-
-        /*
         let mut cksum = u32_from_u16_pair(self.majorVersion, self.minorVersion);
         cksum += self.fontRevision;
         // Skip checksum adjustment (calculated as zero)
         cksum += self.magicNumber;
         cksum += u32_from_u16_pair(self.flags, self.unitsPerEm);
-        chsum += u32_
 
-        cksum += self.manifestStoreOffset + self.manifestStoreLength;
+        let (low, high) = (self.created as u32, (self.created >> 32) as u32);
+        cksum += low;
+        cksum += high;
+
+        let (low, high) = (self.modified as u32, (self.modified >> 32) as u32);
+        cksum += low;
+        cksum += high;
+
+        cksum += u32_from_u16_pair(self.xMin as u16, self.yMin as u16);
+        cksum += u32_from_u16_pair(self.xMax as u16, self.yMax as u16);
+        cksum += u32_from_u16_pair(self.macStyle, self.lowestRecPPEM);
+        cksum += u32_from_u16_pair(self.fontDirectionHint as u16, self.indexToLocFormat as u16);
+        cksum += u32_from_u16_pair(self.glyphDataFormat as u16, 0_u16);
+
         cksum
-        */
     }
 }
 

--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -816,16 +816,11 @@ impl Table for TableDSIG {
         size_of::<Self>() as u32
     }
 
-    // Note: This assumes that the DSIG table is always a dummy table.
     fn checksum(&self) -> Wrapping<u32> {
-        // Write to a temporary buffer.
-        let mut buffer: Vec<u8> = Vec::with_capacity(size_of::<Self>());
-        // TODO: This could fail -- how do we want to handle that?  We could
-        // return a result.. but in doing so we can't call this from the closure
-        // of the foreach anymore (because it can't return a result)...
-        self.write(&mut buffer).unwrap();
-        // Compute the checksum.
-        checksum(&buffer)
+        let mut cksum = Wrapping(self.version);
+        cksum += u32_from_u16_pair(self.numSignatures, self.flags);
+
+        cksum
     }
 }
 

--- a/sdk/src/asset_handlers/font_io.rs
+++ b/sdk/src/asset_handlers/font_io.rs
@@ -92,10 +92,6 @@ pub enum FontError {
 /// Errors that can occur when saving a font.
 #[derive(Debug, thiserror::Error)]
 pub enum FontSaveError {
-    /// Failed to save a font file with an invalid table directory.
-    #[error("Invalid derived table offset bias, an unexpected state.")]
-    InvalidDerivedTableOffsetBias,
-
     /// Failed to save a font file due to the fact the write operation
     /// failed.
     #[error("Failed to save font because the write operation failed; {0}")]
@@ -115,6 +111,10 @@ pub enum FontSaveError {
     /// table directory.
     #[error("Unexpected table found in the table directory: {0}")]
     UnexpectedTable(String),
+
+    // Failed to save a font file with a new table which wasn't C2PA.
+    #[error("New table added which wasn't C2PA")]
+    NonC2PATableAdded,
 }
 
 /// Helper method for wrapping a FontError into a crate level error.
@@ -179,7 +179,7 @@ impl std::fmt::Debug for SfntTag {
 /// assert_eq!(thirty_six_or_forty.2, 40);
 /// assert_eq!(thirty_six_or_forty.3, 40);
 /// ```
-pub(crate) fn align_to_four(size: usize) -> usize {
+pub(crate) fn align_to_four(size: u32) -> u32 {
     (size + 3) & (!3)
 }
 
@@ -348,6 +348,8 @@ pub(crate) trait Table {
     fn write<TDest: Write + ?Sized>(&self, destination: &mut TDest) -> Result<()>;
     /// Calculate the number of bytes of SFNT storage this table will require.
     fn len(&self) -> u32;
+    /// Compute the SFNT-style checksum value of our data.
+    fn checksum(&self) -> Wrapping<u32>;
 }
 
 /// 'C2PA' font table as it appears in storage
@@ -529,28 +531,6 @@ impl TableC2PA {
     pub(crate) fn get_manifest_store(&self) -> Option<&[u8]> {
         self.manifest_store.as_deref()
     }
-
-    /// Compute the SFNT-style checksum value of our data.
-    pub(crate) fn checksum(&self) -> Wrapping<u32> {
-        // Set up the structured data
-        let raw_table = TableC2PARaw::from_table(self);
-        let header_cksum = raw_table.checksum();
-        // Add remote-manifest URI if present.
-        let uri_cksum = if let Some(uri_string) = self.active_manifest_uri.as_ref() {
-            checksum(uri_string.as_bytes())
-        } else {
-            Wrapping(0_u32)
-        };
-        let manifest_cksum = if let Some(manifest_store) = self.manifest_store.as_ref() {
-            checksum_biased(
-                manifest_store.as_bytes(),
-                raw_table.activeManifestUriLength as u32,
-            )
-        } else {
-            Wrapping(0_u32)
-        };
-        header_cksum + uri_cksum + manifest_cksum
-    }
 }
 
 impl Table for TableC2PA {
@@ -583,6 +563,27 @@ impl Table for TableC2PA {
         };
 
         length as u32
+    }
+
+    fn checksum(&self) -> Wrapping<u32> {
+        // Set up the structured data
+        let raw_table = TableC2PARaw::from_table(self);
+        let header_cksum = raw_table.checksum();
+        // Add remote-manifest URI if present.
+        let uri_cksum = if let Some(uri_string) = self.active_manifest_uri.as_ref() {
+            checksum(uri_string.as_bytes())
+        } else {
+            Wrapping(0_u32)
+        };
+        let manifest_cksum = if let Some(manifest_store) = self.manifest_store.as_ref() {
+            checksum_biased(
+                manifest_store.as_bytes(),
+                raw_table.activeManifestUriLength as u32,
+            )
+        } else {
+            Wrapping(0_u32)
+        };
+        header_cksum + uri_cksum + manifest_cksum
     }
 }
 
@@ -733,23 +734,33 @@ impl Table for TableHead {
     }
 
     fn len(&self) -> u32 {
-        // Length is the size of our structure plus two padding bytes.
-        size_of::<TableHead>() as u32 + 2
+        // Length is the size of our structure.
+        size_of::<Self>() as u32
+    }
+
+    fn checksum(&self) -> Wrapping<u32> {
+        // Write to a temporary buffer.
+        let mut buffer: Vec<u8> = Vec::with_capacity(size_of::<Self>());
+        // TODO: This could fail -- how do we want to handle that?  We could
+        // return a result.. but in doing so we can't call this from the closure
+        // of the foreach anymore (because it can't return a result)...
+        self.write(&mut buffer).unwrap();
+        // Compute the checksum.
+        checksum(&buffer)
     }
 }
 
-/// 'DSIG' font table.
+/// 'DSIG' font table, ignores actual signatures as we intend to only use this
+/// as a dummy DSIG table.
 #[allow(non_snake_case)] // As named by Open Font Format / OpenType.
 pub(crate) struct TableDSIG {
     pub version: u32,
     pub numSignatures: u16,
     pub flags: u16,
-    // We don't care about actual signatures; we ignore incoming signatures and
-    // only ever write dummy DSIG tables.
 }
 
 impl TableDSIG {
-    /// Make the DSIG table into an empty dummy DSIG table.
+    /// Create an empty DSIG dummy table.
     pub(crate) fn dummy() -> Self {
         Self {
             version: 1,
@@ -766,7 +777,7 @@ impl TableDSIG {
         size: usize,
     ) -> Result<TableDSIG> {
         reader.seek(SeekFrom::Start(offset))?;
-        let minimum_size = size_of::<TableDSIG>();
+        let minimum_size = size_of::<Self>();
         if size < minimum_size {
             Err(FontError::LoadDSIGTableTruncated)
         } else {
@@ -789,7 +800,19 @@ impl Table for TableDSIG {
     }
 
     fn len(&self) -> u32 {
-        size_of::<TableDSIG>() as u32
+        size_of::<Self>() as u32
+    }
+
+    // Note: This assumes that the DSIG table is always a dummy table.
+    fn checksum(&self) -> Wrapping<u32> {
+        // Write to a temporary buffer.
+        let mut buffer: Vec<u8> = Vec::with_capacity(size_of::<Self>());
+        // TODO: This could fail -- how do we want to handle that?  We could
+        // return a result.. but in doing so we can't call this from the closure
+        // of the foreach anymore (because it can't return a result)...
+        self.write(&mut buffer).unwrap();
+        // Compute the checksum.
+        checksum(&buffer)
     }
 }
 
@@ -833,6 +856,11 @@ impl Table for TableUnspecified {
 
     fn len(&self) -> u32 {
         self.data.len() as u32
+    }
+
+    fn checksum(&self) -> Wrapping<u32> {
+        // Compute the checksum.
+        checksum(&self.data)
     }
 }
 
@@ -890,6 +918,15 @@ impl Table for NamedTable {
             NamedTable::Head(head) => head.len(),
             NamedTable::DSIG(dsig) => dsig.len(),
             NamedTable::Unspecified(un) => un.len(),
+        }
+    }
+
+    fn checksum(&self) -> Wrapping<u32> {
+        match self {
+            NamedTable::C2PA(c2pa) => c2pa.checksum(),
+            NamedTable::Head(head) => head.checksum(),
+            NamedTable::DSIG(dsig) => dsig.checksum(),
+            NamedTable::Unspecified(un) => un.checksum(),
         }
     }
 }

--- a/sdk/src/asset_handlers/sfnt_io.rs
+++ b/sdk/src/asset_handlers/sfnt_io.rs
@@ -335,6 +335,9 @@ impl SfntFont {
             None => {}
         }
 
+        // Sort our directory entries by tag.
+        neo_directory.entries.sort_by_key(|entry| entry.tag);
+
         // Figure the checksum for the whole font - the header, the directory,
         // and then all the tables; we can just use the per-table checksums,
         // since the only one we alter is C2PA, and we just refreshed it...

--- a/sdk/src/asset_handlers/sfnt_io.rs
+++ b/sdk/src/asset_handlers/sfnt_io.rs
@@ -831,6 +831,14 @@ where
             return Err(FontError::InvalidNamedTable("Non-C2PA table with C2PA tag"));
         }
     };
+    // If we had a DSIG table, replace it with a dummy DSIG table.
+    if font.tables.contains_key(&DSIG_TABLE_TAG) {
+        font.tables.remove(&DSIG_TABLE_TAG);
+        font.tables.insert(
+            DSIG_TABLE_TAG,
+            NamedTable::DSIG(TableDSIG::dummy()),
+        );
+    }
     font.write(destination)?;
     Ok(())
 }

--- a/sdk/src/asset_handlers/sfnt_io.rs
+++ b/sdk/src/asset_handlers/sfnt_io.rs
@@ -320,20 +320,20 @@ impl SfntFont {
 
         // If we have a new C2PA table, add a directory entry for it.
         if let Some(c2pa) = self.tables.get(&C2PA_TABLE_TAG) {
-                if !self
-                    .directory
-                    .entries
-                    .iter()
-                    .any(|entry| entry.tag == C2PA_TABLE_TAG)
-                {
-                    let neo_entry = SfntDirectoryEntry {
-                        tag: C2PA_TABLE_TAG,
-                        offset: running_offset,
-                        checksum: c2pa.checksum().0,
-                        length: c2pa.len(),
-                    };
-                    neo_directory.entries.push(neo_entry);
-                }
+            if !self
+                .directory
+                .entries
+                .iter()
+                .any(|entry| entry.tag == C2PA_TABLE_TAG)
+            {
+                let neo_entry = SfntDirectoryEntry {
+                    tag: C2PA_TABLE_TAG,
+                    offset: running_offset,
+                    checksum: c2pa.checksum().0,
+                    length: c2pa.len(),
+                };
+                neo_directory.entries.push(neo_entry);
+            }
         }
 
         // Sort our directory entries by tag.

--- a/sdk/src/asset_handlers/sfnt_io.rs
+++ b/sdk/src/asset_handlers/sfnt_io.rs
@@ -355,7 +355,7 @@ impl SfntFont {
                         },
                         length: match tag {
                             &C2PA_TABLE_TAG => match table {
-                                NamedTable::C2PA(c2pa) => c2pa.len() as u32,
+                                NamedTable::C2PA(c2pa) => c2pa.len(),
                                 _ => {
                                     return Err(FontError::SaveError(
                                         FontSaveError::UnexpectedTable(format!("{:?}", tag)),
@@ -388,7 +388,7 @@ impl SfntFont {
                             tag: *tag,
                             offset: align_to_four(new_data_offset) as u32,
                             checksum: c2pa.checksum().0,
-                            length: c2pa.len() as u32,
+                            length: c2pa.len(),
                         };
                         neo_directory.entries.push(neo_entry);
                         // Note - new_data_offset is never actually used after
@@ -833,6 +833,7 @@ where
     };
     // If we had a DSIG table, replace it with a dummy DSIG table.
     if font.tables.contains_key(&DSIG_TABLE_TAG) {
+        println!("Removing DSIG table");
         font.tables.remove(&DSIG_TABLE_TAG);
         font.tables.insert(
             DSIG_TABLE_TAG,

--- a/sdk/src/asset_handlers/woff_io.rs
+++ b/sdk/src/asset_handlers/woff_io.rs
@@ -368,7 +368,7 @@ impl WoffFont {
         // Store the new directory entry & table.
         self.directory.entries.push(c2pa_entry);
         self.tables
-            .insert(C2PA_TABLE_TAG, NamedTable::C2PA(c2pa_table));
+            .insert(C2PA_TABLE_TAG, NamedTable::C2pa(c2pa_table));
         // Count the table, grow the total size, grow, the "SFNT size"
         self.header.numTables += 1;
         // (TBD compression - conflating comp/uncomp sizes here.)
@@ -731,10 +731,10 @@ where
         None => {
             font.tables.insert(
                 C2PA_TABLE_TAG,
-                NamedTable::C2PA(TableC2PA::new(None, Some(manifest_store_data.to_vec()))),
+                NamedTable::C2pa(TableC2PA::new(None, Some(manifest_store_data.to_vec()))),
             );
         }
-        Some(NamedTable::C2PA(c2pa)) => c2pa.manifest_store = Some(manifest_store_data.to_vec()),
+        Some(NamedTable::C2pa(c2pa)) => c2pa.manifest_store = Some(manifest_store_data.to_vec()),
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
             return Err(FontError::InvalidNamedTable("Non-C2PA table with C2PA tag"));
@@ -773,12 +773,12 @@ where
         None => {
             font.tables.insert(
                 C2PA_TABLE_TAG,
-                NamedTable::C2PA(TableC2PA::new(Some(manifest_uri.to_string()), None)),
+                NamedTable::C2pa(TableC2PA::new(Some(manifest_uri.to_string()), None)),
             );
         }
         // If there is, replace its `active_manifest_uri` value with the
         // provided one.
-        Some(NamedTable::C2PA(c2pa)) => c2pa.active_manifest_uri = Some(manifest_uri.to_string()),
+        Some(NamedTable::C2pa(c2pa)) => c2pa.active_manifest_uri = Some(manifest_uri.to_string()),
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => {
             return Err(FontError::InvalidNamedTable("Non-C2PA table with C2PA tag"));
@@ -906,7 +906,7 @@ where
         None => None,
         // If there is, and it has Some `active_manifest_uri`, then mutate that
         // to None, and return the former value.
-        Some(NamedTable::C2PA(c2pa)) => {
+        Some(NamedTable::C2pa(c2pa)) => {
             if c2pa.active_manifest_uri.is_none() {
                 None
             } else {
@@ -1036,7 +1036,7 @@ fn read_c2pa_from_stream<T: Read + Seek + ?Sized>(reader: &mut T) -> Result<Tabl
         None => Err(FontError::JumbfNotFound),
         // If there is, replace its `manifest_store` value with the
         // provided one.
-        Some(NamedTable::C2PA(c2pa)) => Ok(c2pa.clone()),
+        Some(NamedTable::C2pa(c2pa)) => Ok(c2pa.clone()),
         // Yikes! Non-C2PA table with C2PA tag!
         Some(_) => Err(FontError::InvalidNamedTable("Non-C2PA table with C2PA tag")),
     }


### PR DESCRIPTION
## Changes in this pull request

This PR modifies font signing behavior for SFNT fonts (notably WOFF still has old behavior) such that any DSIG which comes in with a font to be signed will be replaced with a dummy DSIG.  It does this by:
- Adding in a new DSIG names table which allows us to determine if one existed on the incoming font
  - Notably the parser ignores any signatures on the table, as we'll be stomping them anyway
- Looking for an existing DSIG table when the C2PA table is added, and replacing it with a dummy DSIG
- Building up the new TDIR by hand
  - Previously we were sneakier about this, as we knew we'd only ever be adding or removing the whole C2PA table; now that we have two tables changing we can't just rely on an offset shift
  - This required that I add `len` and `checksum` calls to all tables, allowing us to generate TDIR entries for all tables

## Verification

- Check out [c2pa-rs](https://github.com/Monotype/c2pa-rs) with this branch
- Check out [c2patool](https://github.com/Monotype/c2patool)'s `feature/C2PA-262/localSfntSupport` branch in the same directory as `c2pa-rs`
- Build the `c2patool`
- Sign a font with an existing DSIG
- Verify the signed font validates with https://fonttools.monotype.com/validator/options/ (verifies that checksums are all correct and that TDIR is in the proper order)

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
