### PR TITLE
C2PA-518: Take into account italic/bold/non-normal fonts.

### DIFF
--- a/sdk/src/utils/font_thumbnail.rs
+++ b/sdk/src/utils/font_thumbnail.rs
@@ -326,7 +326,7 @@ fn get_skia_paint_for_color<'a>(color: Color) -> tiny_skia::Paint<'a> {
             let (r, g, b, a) = color.as_rgba_tuple();
             tiny_skia::Color::from_rgba8(r, g, b, a)
         }),
-        blend_mode: tiny_skia::BlendMode::Source,
+        blend_mode: tiny_skia::BlendMode::Color,
         anti_alias: false,
         ..Default::default()
     }

--- a/sdk/src/utils/font_thumbnail.rs
+++ b/sdk/src/utils/font_thumbnail.rs
@@ -246,10 +246,7 @@ fn load_font_data<'a>(font_db: &mut Database, data: Vec<u8>) -> Result<LoadedFon
         metadata: 0,
         cache_key_flags: CacheKeyFlags::empty(),
     };
-    Ok(LoadedFont {
-        id: face.id,
-        attrs: attrs.clone(),
-    })
+    Ok(LoadedFont { id: face.id, attrs })
 }
 
 /// Measure the text to get the size of the bounding box required
@@ -380,7 +377,7 @@ pub fn make_thumbnail_from_stream<R: Read + Seek + ?Sized>(
     // Find a buffer that fits the width
     let mut buffer = get_buffer_with_pt_size_fits_width(
         &full_name,
-        attrs.clone(),
+        attrs,
         &mut font_system,
         STARTING_POINT_SIZE,
         font_height,

--- a/sdk/src/utils/font_thumbnail.rs
+++ b/sdk/src/utils/font_thumbnail.rs
@@ -392,7 +392,7 @@ pub fn make_thumbnail_from_stream<R: Read + Seek + ?Sized>(
     // The total width will be our specified width + the width from the italic angle.
     // QUESTION: Should not the `cosmic-text` library really already include this in the
     //           width calculation? Are we doing something wrong?
-    let width = width + width_italic_buffer;
+    let width = width + width_italic_buffer + offset as f32;
 
     // Create a new pixel map for the main text
     let mut img =


### PR DESCRIPTION
## Changes in this pull request

Previously were erroring on looking for fonts with a default Attrs, this addresses that.

## Checklist
- [X] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
