### PR TITLE
C2PA-593: Update the utils::mime to correctly map for fonts.

### DIFF
--- a/sdk/src/utils/mime.rs
+++ b/sdk/src/utils/mime.rs
@@ -91,8 +91,14 @@ pub fn format_to_extension(format: &str) -> Option<&'static str> {
         "arw" | "image/x-sony-arw" => "arw",
         "nef" | "image/x-nikon-nef" => "nef",
         "c2pa" | "application/x-c2pa-manifest-store" | "application/c2pa" => "c2pa",
-        "otf" | "application/x-font-opentype" |"font/otf" => "otf",
-        "ttf" | "sfnt" | "font/ttf" | "application/font-sfnt" | "application/x-font-ttf" | "application/x-font-truetype" | "font/sfnt" => "ttf",
+        "otf" | "application/x-font-opentype" | "font/otf" => "otf",
+        "ttf"
+        | "sfnt"
+        | "font/ttf"
+        | "application/font-sfnt"
+        | "application/x-font-ttf"
+        | "application/x-font-truetype"
+        | "font/sfnt" => "ttf",
         _ => return None,
     })
 }

--- a/sdk/src/utils/mime.rs
+++ b/sdk/src/utils/mime.rs
@@ -42,6 +42,8 @@ pub fn extension_to_mime(extension: &str) -> Option<&'static str> {
         "arw" => "image/x-sony-arw",
         "nef" => "image/x-nikon-nef",
         "c2pa" | "application/x-c2pa-manifest-store" | "application/c2pa" => "application/c2pa",
+        "otf" => "font/otf",
+        "ttf" => "font/ttf",
         _ => return None,
     })
 }
@@ -89,6 +91,8 @@ pub fn format_to_extension(format: &str) -> Option<&'static str> {
         "arw" | "image/x-sony-arw" => "arw",
         "nef" | "image/x-nikon-nef" => "nef",
         "c2pa" | "application/x-c2pa-manifest-store" | "application/c2pa" => "c2pa",
+        "otf" | "application/x-font-opentype" |"font/otf" => "otf",
+        "ttf" | "sfnt" | "font/ttf" | "application/font-sfnt" | "application/x-font-ttf" | "application/x-font-truetype" | "font/sfnt" => "ttf",
         _ => return None,
     })
 }


### PR DESCRIPTION
## Changes in this pull request
The `utils::mime` functions were not correctly working for font types.

## Checklist
- [X] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
