### PR TITLE
C2PA-593: thumbnail SVG content type

### DIFF
--- a/sdk/src/assertions/labels.rs
+++ b/sdk/src/assertions/labels.rs
@@ -89,6 +89,16 @@ pub const PNG_CLAIM_THUMBNAIL: &str = "c2pa.thumbnail.claim.png";
 /// See <https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_thumbnail>.
 pub const PNG_INGREDIENT_THUMBNAIL: &str = "c2pa.thumbnail.ingredient.png";
 
+/// Label prefix for a SVG claim thumbnail assertion.
+///
+/// See <https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_thumbnail>.
+pub const SVG_CLAIM_THUMBNAIL: &str = "c2pa.thumbnail.claim.svg";
+
+/// Label prefix for a SVG ingredient thumbnail assertion.
+///
+/// See <https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_thumbnail>.
+pub const SVG_INGREDIENT_THUMBNAIL: &str = "c2pa.thumbnail.ingredient.svg";
+
 /// Label prefix for an actions assertion.
 ///
 /// See <https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_actions>.
@@ -194,6 +204,7 @@ pub fn add_thumbnail_format(label: &str, format: &str) -> String {
     match format {
         "image/jpeg" | "jpeg" | "jpg" => format!("{label}.jpeg"),
         "image/png" | "png" => format!("{label}.png"),
+        "image/svg+xml" | "svg" => format!("{label}.svg"),
         _ => {
             let p: Vec<&str> = format.split('/').collect();
             if p.len() == 2 && p[0] == "image" {

--- a/sdk/src/assertions/thumbnail.rs
+++ b/sdk/src/assertions/thumbnail.rs
@@ -40,6 +40,7 @@ impl Thumbnail {
             "tiff" => "image/tiff",
             "ico" => "image/x-icon",
             "webp" => "image/webp",
+            "svg" => "image/svg+xml",
             _ => "application/octet-stream",
         }
         .to_string();
@@ -112,8 +113,10 @@ pub mod tests {
     fn assertion_thumbnail_valid() {
         thumbnail_test(labels::JPEG_CLAIM_THUMBNAIL, "image/jpeg");
         thumbnail_test(labels::PNG_CLAIM_THUMBNAIL, "image/png");
+        thumbnail_test(labels::SVG_CLAIM_THUMBNAIL, "image/svg+xml");
         thumbnail_test(labels::JPEG_INGREDIENT_THUMBNAIL, "image/jpeg");
         thumbnail_test(labels::PNG_INGREDIENT_THUMBNAIL, "image/png");
+        thumbnail_test(labels::SVG_INGREDIENT_THUMBNAIL, "image/svg+xml");
         // unrecognized labels will be formatted as octet_streams
         thumbnail_test("foo", "application/octet-stream");
     }


### PR DESCRIPTION
## Changes in this pull request
_Give a narrative description of what has been changed._

This correctly labels SVG thumbnails with the correct format/content-type, in accordance with the specification [here](https://c2pa.org/specifications/specifications/2.1/specs/C2PA_Specification.html#thumbnail_assertion) and [here](https://www.iana.org/assignments/media-types/image/svg+xml).

When signing a font now with the features `add_svg_font_thumbnails`, you should get the thumbnail correctly labeled as `image/svg+xml`:

<img width="554" alt="image" src="https://github.com/user-attachments/assets/ce98dd2d-fc0a-4c53-b7b6-cdaa294d5eb3">


## Checklist
- [X] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
