### PR TITLE
fix: C2PA-641/C2PA-642: Remove a C2PA table if-and-only-if it exist

### DIFF
--- a/sdk/src/asset_handlers/sfnt_io.rs
+++ b/sdk/src/asset_handlers/sfnt_io.rs
@@ -365,8 +365,11 @@ where
 {
     source.rewind()?;
     let mut font = SfntFont::from_reader(source)?;
-    // Remove the C2PA record from the font
-    font.remove_c2pa_record()?;
+    // Only remove if it has C2PA
+    if font.has_c2pa() {
+        // Remove the C2PA record from the font
+        font.remove_c2pa_record()?;
+    }
     // And write it to the destination stream
     font.write(destination)?;
     Ok(())

--- a/sdk/src/asset_handlers/sfnt_io.rs
+++ b/sdk/src/asset_handlers/sfnt_io.rs
@@ -1480,6 +1480,5 @@ pub mod tests {
             Err(Error::JumbfNotFound) => (),
             _ => unreachable!(),
         }
-
     }
 }

--- a/sdk/src/asset_handlers/sfnt_io.rs
+++ b/sdk/src/asset_handlers/sfnt_io.rs
@@ -1455,4 +1455,31 @@ pub mod tests {
             _ => unreachable!(),
         }
     }
+
+    #[test]
+    fn test_remove_c2pa_from_stream_which_doesnot_have_one() {
+        let source = fixture_path("font.otf");
+
+        let source_bytes = std::fs::read(source).unwrap();
+        let mut source_stream = Cursor::new(source_bytes);
+
+        let sfnt_io = SfntIO {};
+        let sfnt_writer = sfnt_io.get_writer("ttf").unwrap();
+
+        let output_bytes = Vec::new();
+        let mut output_stream = Cursor::new(output_bytes);
+
+        sfnt_writer
+            .remove_cai_store_from_stream(&mut source_stream, &mut output_stream)
+            .unwrap();
+
+        // read back in asset, JumbfNotFound is expected since it was removed
+        let sfnt_reader = sfnt_io.get_reader();
+        assert_ok!(output_stream.rewind());
+        match sfnt_reader.read_cai(&mut output_stream) {
+            Err(Error::JumbfNotFound) => (),
+            _ => unreachable!(),
+        }
+
+    }
 }


### PR DESCRIPTION
## Changes in this pull request
_Give a narrative description of what has been changed._

During the previous adaption of the `c2pa-font-handler` crate, we inadvertently changed the behavior when asked to remove a C2PA record from a font which didn't have one. Instead of erroring out, we will now check to see if it exist first.

For verification purposes, lines 368-372 can be reverted and run the new unit test for verification purposes. This is also noticeable when doing a remote manifest.

## Checklist
- [X] This PR represents a single feature, fix, or change.
- [X] All applicable changes have been documented.
- [X] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
