### PR TITLE
fix: C2PA-718/C2P-143: Update to the test branch for testing purposes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ dependencies = [
  "sha2",
  "spki",
  "static-iref",
- "svg",
+ "svg 0.17.0",
  "tempfile",
  "thiserror 2.0.12",
  "tiny-skia",
@@ -865,17 +865,21 @@ dependencies = [
 
 [[package]]
 name = "c2pa-font-handler"
-version = "0.4.3"
-source = "git+https://github.com/Monotype/c2pa-font-handler?tag=v0.4.3#f066403f7e125774f84a31bbdff407c6fdb09268"
+version = "0.4.5"
+source = "git+https://github.com/Monotype/c2pa-font-handler?branch=fix/C2PA-718/C2P-143/handleBadC2paTableLocation#65e678d9a491f3b9adfeef39e3786b35f4d005a1"
 dependencies = [
  "anyhow",
  "byteorder",
  "bytes",
+ "cosmic-text",
  "flate2",
+ "resvg",
  "serde",
  "serde_json",
+ "svg 0.18.0",
  "thiserror 2.0.12",
  "tracing",
+ "unicode-script",
 ]
 
 [[package]]
@@ -1376,7 +1380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.101",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3974,9 +3978,9 @@ dependencies = [
 
 [[package]]
 name = "resvg"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd43d1c474e9dadf09a8fdf22d713ba668b499b5117b9b9079500224e26b5b29"
+checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
 dependencies = [
  "gif",
  "image-webp",
@@ -4695,6 +4699,12 @@ name = "svg"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "700efb40f3f559c23c18b446e8ed62b08b56b2bb3197b36d57e0470b4102779e"
+
+[[package]]
+name = "svg"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94afda9cd163c04f6bee8b4bf2501c91548deae308373c436f36aeff3cf3c4a3"
 
 [[package]]
 name = "svgtypes"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,7 +866,7 @@ dependencies = [
 [[package]]
 name = "c2pa-font-handler"
 version = "0.4.5"
-source = "git+https://github.com/Monotype/c2pa-font-handler?branch=fix/C2PA-718/C2P-143/handleBadC2paTableLocation#65e678d9a491f3b9adfeef39e3786b35f4d005a1"
+source = "git+https://github.com/Monotype/c2pa-font-handler?branch=dev#61e88a79b7eebff092a3514e42e93c1f70448c03"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,8 +865,8 @@ dependencies = [
 
 [[package]]
 name = "c2pa-font-handler"
-version = "0.4.5"
-source = "git+https://github.com/Monotype/c2pa-font-handler?branch=dev#61e88a79b7eebff092a3514e42e93c1f70448c03"
+version = "0.5.0"
+source = "git+https://github.com/Monotype/c2pa-font-handler?tag=v0.5.0#99cda09066c961aec4b5ff9693f7ad9d6d66c259"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -89,7 +89,7 @@ bytes = "1.7.2"
 byteorder = { version = "1.4.3", default-features = false }
 byteordered = "0.6.0"
 #c2pa-font-handler = { tag = "v0.4.3", git = "https://github.com/Monotype/c2pa-font-handler", optional = true }
-c2pa-font-handler = { branch = "fix/C2PA-718/C2P-143/handleBadC2paTableLocation", git = "https://github.com/Monotype/c2pa-font-handler", optional = true }
+c2pa-font-handler = { branch = "dev", git = "https://github.com/Monotype/c2pa-font-handler", optional = true }
 chrono = { version = "0.4.39", default-features = false, features = ["serde"] }
 ciborium = "0.2.2"
 config = { version = "0.14.0", default-features = false, features = [

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -88,7 +88,8 @@ bcder = "0.7.3"
 bytes = "1.7.2"
 byteorder = { version = "1.4.3", default-features = false }
 byteordered = "0.6.0"
-c2pa-font-handler = { tag = "v0.4.3", git = "https://github.com/Monotype/c2pa-font-handler", optional = true }
+#c2pa-font-handler = { tag = "v0.4.3", git = "https://github.com/Monotype/c2pa-font-handler", optional = true }
+c2pa-font-handler = { branch = "fix/C2PA-718/C2P-143/handleBadC2paTableLocation", git = "https://github.com/Monotype/c2pa-font-handler", optional = true }
 chrono = { version = "0.4.39", default-features = false, features = ["serde"] }
 ciborium = "0.2.2"
 config = { version = "0.14.0", default-features = false, features = [

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -88,8 +88,7 @@ bcder = "0.7.3"
 bytes = "1.7.2"
 byteorder = { version = "1.4.3", default-features = false }
 byteordered = "0.6.0"
-#c2pa-font-handler = { tag = "v0.4.3", git = "https://github.com/Monotype/c2pa-font-handler", optional = true }
-c2pa-font-handler = { branch = "dev", git = "https://github.com/Monotype/c2pa-font-handler", optional = true }
+c2pa-font-handler = { tag = "v0.5.0", git = "https://github.com/Monotype/c2pa-font-handler", optional = true }
 chrono = { version = "0.4.39", default-features = false, features = ["serde"] }
 ciborium = "0.2.2"
 config = { version = "0.14.0", default-features = false, features = [


### PR DESCRIPTION
This picks up the change in the `c2pa-font-handler`, for when a font may already have a C2PA table, but it was not written at the end of the font stream.