### PR TITLE
chore: upcoming clippy fixes (cherry picked from 2780cf12e4d7939da05e3189ab4ce17eac8a3d83)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        rust_version: [stable, 1.85.0]
+        rust_version: [stable, 1.87.0]
 
     steps:
       - name: Checkout repository
@@ -224,7 +224,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [aarch64-unknown-linux-gnu]
-        rust_version: [stable, 1.85.0]
+        rust_version: [stable, 1.87.0]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        rust_version: [stable, 1.82.0]
+        rust_version: [stable, 1.85.0]
 
     steps:
       - name: Checkout repository
@@ -224,7 +224,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [aarch64-unknown-linux-gnu]
-        rust_version: [stable, 1.82.0]
+        rust_version: [stable, 1.85.0]
 
     steps:
       - name: Checkout repository

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,7 +11,7 @@ The C2PA Rust library has been tested on:
 
 ## Requirements
 
-The C2PA Rust library requires **Rust version 1.82.0** or newer.
+The C2PA Rust library requires **Rust version 1.85.0** or newer.
 
 To use the library, add this to your `Cargo.toml`:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,7 +11,7 @@ The C2PA Rust library has been tested on:
 
 ## Requirements
 
-The C2PA Rust library requires **Rust version 1.85.0** or newer.
+The C2PA Rust library requires **Rust version 1.87.0** or newer.
 
 To use the library, add this to your `Cargo.toml`:
 

--- a/export_schema/Cargo.toml
+++ b/export_schema/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.36.1"
 authors = ["Dave Kozma <dkozma@adobe.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
-rust-version = "1.82.0"
+rust-version = "1.85.0"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }

--- a/export_schema/Cargo.toml
+++ b/export_schema/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.36.1"
 authors = ["Dave Kozma <dkozma@adobe.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
-rust-version = "1.85.0"
+rust-version = "1.87.0"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.49.5"
 authors = ["Gavin Peacock <gpeacock@adobe.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.82.0"
+rust-version = "1.85.0"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }

--- a/make_test_images/Cargo.toml
+++ b/make_test_images/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.49.5"
 authors = ["Gavin Peacock <gpeacock@adobe.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.85.0"
+rust-version = "1.87.0"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(test)'] }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -18,7 +18,7 @@ readme = "../README.md"
 keywords = ["xmp", "metadata"]
 categories = ["api-bindings"]
 edition = "2021"
-rust-version = "1.85.0"
+rust-version = "1.87.0"
 exclude = ["tests/fixtures"]
 
 [package.metadata.docs.rs]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -18,7 +18,7 @@ readme = "../README.md"
 keywords = ["xmp", "metadata"]
 categories = ["api-bindings"]
 edition = "2021"
-rust-version = "1.82.0"
+rust-version = "1.85.0"
 exclude = ["tests/fixtures"]
 
 [package.metadata.docs.rs]

--- a/sdk/src/assertions/uuid_assertion.rs
+++ b/sdk/src/assertions/uuid_assertion.rs
@@ -17,6 +17,7 @@ use crate::{
 };
 
 /// Helper class to create User assertion
+#[allow(dead_code)]
 #[derive(Debug, Default)]
 pub struct Uuid {
     label: String,

--- a/sdk/src/asset_handlers/svg_io.rs
+++ b/sdk/src/asset_handlers/svg_io.rs
@@ -163,7 +163,7 @@ impl AssetIO for SvgIO {
 }
 
 // create manifest entry
-fn create_manifest_tag(data: &[u8], with_meta: bool) -> Result<Event> {
+fn create_manifest_tag(data: &[u8], with_meta: bool) -> Result<Event<'_>> {
     let output: Vec<u8> = Vec::with_capacity(data.len() + 256);
     let mut writer = Writer::new(Cursor::new(output));
 

--- a/sdk/src/crypto/ec_utils.rs
+++ b/sdk/src/crypto/ec_utils.rs
@@ -55,7 +55,7 @@ impl EcdsaCurve {
 /// Parse an ASN.1 DER object that contains a P1363 format into its components.
 ///
 /// This format is used by C2PA to describe ECDSA signature keys.
-pub(crate) fn parse_ec_der_sig(data: &[u8]) -> BerResult<EcSigComps> {
+pub(crate) fn parse_ec_der_sig(data: &[u8]) -> BerResult<'_, EcSigComps<'_>> {
     parse_der_sequence_defined_g(|content: &[u8], _| {
         let (rem1, r) = parse_der_integer(content)?;
         let (_rem2, s) = parse_der_integer(rem1)?;

--- a/sdk/src/dynamic_assertion.rs
+++ b/sdk/src/dynamic_assertion.rs
@@ -183,7 +183,7 @@ pub struct PartialClaim {
 
 impl PartialClaim {
     /// Return an iterator over the assertions in this Claim.
-    pub fn assertions(&self) -> Iter<HashedUri> {
+    pub fn assertions(&self) -> Iter<'_, HashedUri> {
         self.assertion_uris.iter()
     }
 

--- a/sdk/src/identity/claim_aggregation/w3c_vc/did.rs
+++ b/sdk/src/identity/claim_aggregation/w3c_vc/did.rs
@@ -122,7 +122,7 @@ impl DidBuf {
         }
     }
 
-    pub fn as_did(&self) -> Did {
+    pub fn as_did(&self) -> Did<'_> {
         unsafe {
             // SAFETY: we validated the data in `Self::new`.
             Did::new_unchecked(&self.0)

--- a/sdk/src/ingredient.rs
+++ b/sdk/src/ingredient.rs
@@ -251,14 +251,14 @@ impl Ingredient {
     }
 
     /// Returns thumbnail tuple Some((format, bytes)) or None.
-    pub fn thumbnail(&self) -> Option<(&str, Cow<Vec<u8>>)> {
+    pub fn thumbnail(&self) -> Option<(&str, Cow<'_, Vec<u8>>)> {
         self.thumbnail
             .as_ref()
             .and_then(|t| Some(t.format.as_str()).zip(self.resources.get(&t.identifier).ok()))
     }
 
     /// Returns a Cow of thumbnail bytes or Err(Error::NotFound)`.
-    pub fn thumbnail_bytes(&self) -> Result<Cow<Vec<u8>>> {
+    pub fn thumbnail_bytes(&self) -> Result<Cow<'_, Vec<u8>>> {
         match self.thumbnail.as_ref() {
             Some(thumbnail) => self.resources.get(&thumbnail.identifier),
             None => Err(Error::NotFound),
@@ -313,7 +313,7 @@ impl Ingredient {
     /// Returns a copy on write ref to the manifest data bytes or None`.
     ///
     /// manifest_data is the binary form of a manifest store in .c2pa format.
-    pub fn manifest_data(&self) -> Option<Cow<Vec<u8>>> {
+    pub fn manifest_data(&self) -> Option<Cow<'_, Vec<u8>>> {
         self.manifest_data
             .as_ref()
             .and_then(|r| self.resources.get(&r.identifier).ok())

--- a/sdk/src/manifest.rs
+++ b/sdk/src/manifest.rs
@@ -194,8 +194,8 @@ impl Manifest {
         self.title.as_deref()
     }
 
-    /// Returns thumbnail tuple with Some((format, bytes)) or None
-    pub fn thumbnail(&self) -> Option<(&str, Cow<Vec<u8>>)> {
+    /// Returns thumbnail tuple with Some((format, bytes)) or `None`.
+    pub fn thumbnail(&self) -> Option<(&str, Cow<'_, Vec<u8>>)> {
         self.thumbnail
             .as_ref()
             .and_then(|t| Some(t.format.as_str()).zip(self.resources.get(&t.identifier).ok()))
@@ -223,8 +223,8 @@ impl Manifest {
         &self.assertions
     }
 
-    /// Returns raw assertion references
-    pub fn assertion_references(&self) -> Iter<HashedUri> {
+    /// Returns raw assertion references.
+    pub fn assertion_references(&self) -> Iter<'_, HashedUri> {
         self.assertion_references.iter()
     }
 

--- a/sdk/src/resource_store.rs
+++ b/sdk/src/resource_store.rs
@@ -290,7 +290,7 @@ impl ResourceStore {
     /// Returns a copy on write reference to the resource if found.
     ///
     /// Returns [`Error::ResourceNotFound`] if it cannot find a resource matching that ID.
-    pub fn get(&self, id: &str) -> Result<Cow<Vec<u8>>> {
+    pub fn get(&self, id: &str) -> Result<Cow<'_, Vec<u8>>> {
         #[cfg(feature = "file_io")]
         if !self.resources.contains_key(id) {
             match self.base_path.as_ref() {

--- a/sdk/src/utils/cbor_types.rs
+++ b/sdk/src/utils/cbor_types.rs
@@ -100,6 +100,7 @@ impl fmt::Display for UriT {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BytesT(pub Vec<u8>);
 


### PR DESCRIPTION
There were clippy issues, but we can't quite pick up all the changes from `main` at this point. So I cherry picked the 2780cf12e4d7939da05e3189ab4ce17eac8a3d83 commit which fixes the issues.